### PR TITLE
Add tool to install CA certificates to system trust store.

### DIFF
--- a/_build/calculate-container-hash.sh
+++ b/_build/calculate-container-hash.sh
@@ -20,8 +20,11 @@ for dir in ${*}; do
             # order of their entries is interdeterminate. While there are flags to
             # address those, I could not get it to work reliably. Instead, we
             # are going to hash the contents of every python file...
+	    #
+	    # Additionally, I exclude kolla-ansible here because its code does not
+	    # change the content of images.
             echo "Using src hashing for ${dir}..." >&2
-            hash=$(find . -type f -name "*.py" -exec cat {} \; | sort | sha1sum - | cut -f 1 -d " " | sed -rn 's/^(........).*/\1/gp')
+            hash=$(find . -type f -name "*.py" -path "./kolla-ansible" -prune -exec cat {} \; | sort | sha1sum - | cut -f 1 -d " " | sed -rn 's/^(........).*/\1/gp')
             unique="${unique};${hash}"
         elif [ $(echo "_build etc tools" | grep -c "${dir}" || true) -gt 0 ]; then
             # These directories are like `src`, but has a simpler structure and

--- a/kolla-ansible-wave-1/config.yaml
+++ b/kolla-ansible-wave-1/config.yaml
@@ -3,7 +3,7 @@ source_branch: master
 destination_branch: spice-direct-consoles
 shallow_clone: false
 directory: kolla-ansible
-release: master
+release: master-wave1
 depends_on: ''
 source_sha: 3bd221a98819d271f3629b6a95f16da89b1ba303
 previous_source_sha: 0311c0bed06b872bb19516904f9887eedaad5d7f

--- a/kolla-ansible/config.yaml
+++ b/kolla-ansible/config.yaml
@@ -5,4 +5,4 @@ shallow_clone: false
 directory: kolla-ansible
 release: master
 depends_on: ''
-source_sha: 0311c0bed06b872bb19516904f9887eedaad5d7f
+source_sha: b1fce586d82b28104f3ceb560b2ba0e5278c4bdc

--- a/kolla-ansible/config.yaml
+++ b/kolla-ansible/config.yaml
@@ -5,4 +5,4 @@ shallow_clone: false
 directory: kolla-ansible
 release: master
 depends_on: ''
-source_sha: b1fce586d82b28104f3ceb560b2ba0e5278c4bdc
+source_sha: d34b9891ae9876a531f06e5e42cc639320d442cb

--- a/tools/add-ca-certificate
+++ b/tools/add-ca-certificate
@@ -1,0 +1,109 @@
+#!/bin/bash -e
+
+# Add a CA certificate to the system trust store
+# Works on both Debian-based and RHEL-based (Rocky Linux) distributions
+
+# Check if certificate file is provided
+if [ -z "$1" ]; then
+    echo "Usage: $0 <certificate-file>"
+    echo "  certificate-file: Path to the CA certificate (PEM format)"
+    exit 1
+fi
+
+CERT_FILE="$1"
+
+# Validate certificate file exists
+if [ ! -f "${CERT_FILE}" ]; then
+    echo "Error: Certificate file '${CERT_FILE}' not found"
+    exit 1
+fi
+
+# Validate it's a valid certificate
+if ! openssl x509 -in "${CERT_FILE}" -noout 2>/dev/null; then
+    echo "Error: '${CERT_FILE}' does not appear to be a valid X.509 certificate"
+    exit 1
+fi
+
+# Detect the OS
+. /etc/os-release
+
+# Generate a certificate name based on the subject
+CERT_SUBJECT=$(openssl x509 -in "${CERT_FILE}" -noout -subject | sed 's/subject=//' | sed 's/[^a-zA-Z0-9]/_/g')
+CERT_NAME="${CERT_SUBJECT}.crt"
+
+# Get the certificate fingerprint for verification
+CERT_FINGERPRINT=$(openssl x509 -in "${CERT_FILE}" -noout -fingerprint -sha256 | cut -d= -f2)
+
+echo "Adding CA certificate to system trust store..."
+echo "Certificate: ${CERT_FILE}"
+echo "Fingerprint: ${CERT_FINGERPRINT}"
+echo "OS: ${ID}"
+
+if [ "${ID}" == "debian" ] || [ "${ID}" == "ubuntu" ]; then
+    # Debian/Ubuntu
+    TARGET_DIR="/usr/local/share/ca-certificates"
+    TARGET_FILE="${TARGET_DIR}/${CERT_NAME}"
+    BUNDLE_PATH="/etc/ssl/certs/ca-certificates.crt"
+
+    echo "Installing to ${TARGET_FILE}"
+    sudo mkdir -p "${TARGET_DIR}"
+    sudo cp "${CERT_FILE}" "${TARGET_FILE}"
+    sudo chmod 644 "${TARGET_FILE}"
+
+    echo "Updating CA certificates..."
+    sudo update-ca-certificates
+
+    echo "✓ Certificate added successfully"
+    echo "System bundle: ${BUNDLE_PATH}"
+
+elif [ "${ID}" == "rocky" ] || [ "${ID}" == "rhel" ] || [ "${ID}" == "centos" ] || [ "${ID}" == "fedora" ]; then
+    # RHEL-based (Rocky Linux, CentOS, Fedora)
+    TARGET_DIR="/etc/pki/ca-trust/source/anchors"
+    TARGET_FILE="${TARGET_DIR}/${CERT_NAME}"
+    BUNDLE_PATH="/etc/pki/tls/certs/ca-bundle.crt"
+
+    echo "Installing to ${TARGET_FILE}"
+    sudo mkdir -p "${TARGET_DIR}"
+    sudo cp "${CERT_FILE}" "${TARGET_FILE}"
+    sudo chmod 644 "${TARGET_FILE}"
+
+    echo "Updating CA trust..."
+    sudo update-ca-trust extract
+
+    echo "✓ Certificate added successfully"
+    echo "System bundle: ${BUNDLE_PATH}"
+
+else
+    echo "Error: Unsupported distribution: ${ID}"
+    echo "Supported: debian, ubuntu, rocky, rhel, centos, fedora"
+    exit 1
+fi
+
+# Verify the certificate was added by checking if our fingerprint is in the bundle
+echo ""
+echo "Verifying installation..."
+
+# Extract all certificates from the bundle and check fingerprints
+TEMP_BUNDLE="/tmp/bundle_verify_$$"
+csplit -s -z -f "${TEMP_BUNDLE}_" -b "%04d.crt" "${BUNDLE_PATH}" '/-----BEGIN CERTIFICATE-----/' '{*}'
+
+FOUND=0
+for cert in ${TEMP_BUNDLE}_*.crt; do
+    if [ -f "${cert}" ]; then
+        BUNDLE_FINGERPRINT=$(openssl x509 -in "${cert}" -noout -fingerprint -sha256 2>/dev/null | cut -d= -f2)
+        if [ "${BUNDLE_FINGERPRINT}" == "${CERT_FINGERPRINT}" ]; then
+            FOUND=1
+            break
+        fi
+    fi
+done
+
+# Cleanup temp files
+rm -f ${TEMP_BUNDLE}_*.crt
+
+if [ ${FOUND} -eq 1 ]; then
+    echo "✓ Verification passed - certificate found in system bundle"
+else
+    echo "⚠ Warning: Certificate not found in system bundle"
+    exit 1
+fi


### PR DESCRIPTION
Adds a new bash script that can install CA certificates into the system trust store on both Debian-based and RHEL-based distributions. The script validates certificates, detects the OS, installs to the appropriate location, updates the trust store, and verifies the certificate was added by comparing SHA256 fingerprints.

The functional test workflow now uses this tool to fetch the Kolla-Ansible CA certificate and add it to the runner's system trust store, allowing direct verification of HTTPS endpoints. This replaces several verbose debug output steps that were previously used for troubleshooting.

Prompt: Let's develop a bash script in kerbside-patches/tools which can add a new CA certificate to the system bundle on both Debian Linux and Rocky Linux.

Assisted-By: Claude Code <noreply@anthropic.com>