### PR TITLE
Separate out the network nodes for multinode CI.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -296,7 +296,7 @@ jobs:
             'release': 'master',
             'base': 'debian:12',
             'baseuser': 'debian',
-            'topology': 'multinode',
+            'topology': 'multinode-2',
             'runs_on': 'debian-12',
             'container_distro': 'debian'
           },

--- a/etc/inventory-multinode-2-master
+++ b/etc/inventory-multinode-2-master
@@ -12,8 +12,8 @@ control-1
 control-2
 
 [network]
-control-1
-control-2
+network-1
+network-2
 
 [compute]
 compute-1
@@ -48,6 +48,7 @@ vdiproxy
 
 [tls-backend:children]
 control
+network
 vdiproxy
 
 # You can explicitly specify which hosts run each project by updating the
@@ -265,10 +266,16 @@ control
 vdiproxy
 
 # Neutron
-[neutron-server:children]
-control
+[ironic-neutron-agent:children]
+neutron
+
+[neutron-bgp-dragent:children]
+neutron
 
 [neutron-dhcp-agent:children]
+neutron
+
+[neutron-infoblox-ipam-agent:children]
 neutron
 
 [neutron-l3-agent:children]
@@ -277,23 +284,26 @@ neutron
 [neutron-metadata-agent:children]
 neutron
 
-[neutron-ovn-metadata-agent:children]
-compute
-network
-
-[neutron-bgp-dragent:children]
-neutron
-
-[neutron-infoblox-ipam-agent:children]
-neutron
-
 [neutron-metering-agent:children]
 neutron
 
-[ironic-neutron-agent:children]
-neutron
+[neutron-periodic-worker:children]
+control
+
+[neutron-rpc-server:children]
+control
+
+[neutron-server:children]
+control
 
 [neutron-ovn-agent:children]
+compute
+network
+
+[neutron-ovn-maintenance-worker:children]
+control
+
+[neutron-ovn-metadata-agent:children]
 compute
 network
 


### PR DESCRIPTION
This will hopefully help surface possible certificate problems.