### PR TITLE
Add Claude Code auto-fix to daily rebase workflow.

### DIFF
--- a/.github/workflows/daily-rebase-checks.yml
+++ b/.github/workflows/daily-rebase-checks.yml
@@ -31,18 +31,6 @@ jobs:
           path: kerbside-patches
           fetch-depth: 0
 
-      - name: Install the github command line
-        run: |
-          sudo apt update
-          sudo apt install -y curl python3 python3-venv python3-wheel
-
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-
-          sudo apt update
-          sudo apt install -y gh
-
       - name: Bump rebase field in README.md, and source SHAs
         env:
           GITHUB_TOKEN: ${{ secrets.DAILY_REBASE_TOKEN }}

--- a/.github/workflows/daily-rebase-checks.yml
+++ b/.github/workflows/daily-rebase-checks.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   daily-rebase:
-    runs-on: [self-hosted, vm]
-    timeout-minutes: 60
+    runs-on: [self-hosted, claude-code]
+    timeout-minutes: 120
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
@@ -22,6 +22,8 @@ jobs:
         run: |
           echo "SF_HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
           echo "SHAKENFIST_NAMESPACE=$(hostname)" >> $GITHUB_ENV
+          echo "DATESTAMP=$(date '+%Y%m%d')" >> $GITHUB_ENV
+          echo "DATEPRETTY=$(date '+%-d %B %Y')" >> $GITHUB_ENV
 
       - name: Checkout kerbside-patches
         uses: actions/checkout@v4
@@ -51,12 +53,10 @@ jobs:
 
           cd ${GITHUB_WORKSPACE}/kerbside-patches
 
-          datestamp=$(date "+%Y%m%d")
-          datepretty=$(date "+%-d %B %Y")
-          git checkout -b daily-rebase-${datestamp}
+          git checkout -b daily-rebase-${DATESTAMP}
 
           # Bump the description in README.md
-          cat README.md.tmpl | sed "s/%%date%%/${datepretty}/" > README.md
+          cat README.md.tmpl | sed "s/%%date%%/${DATEPRETTY}/" > README.md
 
           # Lock in new daily SHAs
           _build/bump-source-shas.sh 1
@@ -66,20 +66,231 @@ jobs:
           git diff
           echo
 
-          echo "Commit changes and push to github..."
+          echo "Commit changes..."
           git config --global user.name "shakenfist-bot"
           git config --global user.email "bot@shakenfist.com"
-          git commit -a -m "Daily rebase for ${datestamp}."
-          git push -f origin daily-rebase-${datestamp}
+          git commit -a -m "Daily rebase for ${DATESTAMP}."
+
+      - name: Test patch application
+        id: test-patches
+        continue-on-error: true
+        run: |
+          . ${GITHUB_WORKSPACE}/_venv/bin/activate
+          cd ${GITHUB_WORKSPACE}/kerbside-patches
+
+          # Run patch tests and capture results
+          set +e
+          ./_build/test-patches-for-ci.sh > ${GITHUB_WORKSPACE}/patch-test-results.json 2>&1
+          test_exit_code=$?
+          set -e
+
+          echo "Test exit code: ${test_exit_code}"
+          echo "Test results:"
+          cat ${GITHUB_WORKSPACE}/patch-test-results.json
+
+          if [ ${test_exit_code} -ne 0 ]; then
+            echo "patches_failed=true" >> $GITHUB_OUTPUT
+
+            # Extract failure details using helper script
+            cat ${GITHUB_WORKSPACE}/patch-test-results.json | \
+                ./_build/extract-patch-failures.py > ${GITHUB_WORKSPACE}/patch-failures.txt
+            echo "Failure details:"
+            cat ${GITHUB_WORKSPACE}/patch-failures.txt
+          else
+            echo "patches_failed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check Claude Code availability
+        if: steps.test-patches.outputs.patches_failed == 'true'
+        id: claude-check
+        run: |
+          if command -v claude &> /dev/null; then
+            echo "Claude Code CLI found at: $(which claude)"
+            echo "claude_available=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::Claude Code CLI not found on this runner"
+            echo "claude_available=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Attempt Claude Code patch fix
+        if: |
+          steps.test-patches.outputs.patches_failed == 'true' &&
+          steps.claude-check.outputs.claude_available == 'true'
+        id: claude-fix
+        run: |
+          cd ${GITHUB_WORKSPACE}/kerbside-patches
+
+          # Build the prompt
+          cat > ${GITHUB_WORKSPACE}/claude-prompt.txt << 'PROMPT_EOF'
+          A patch has failed to apply during the daily rebase of the
+          kerbside-patches repository. Please fix the failing patch.
+
+          ## Context
+
+          This repository maintains patches against OpenStack components
+          (kolla, kolla-ansible, nova). The workflow has already:
+          1. Updated source SHAs in config.yaml files to latest upstream
+          2. Attempted to apply patches with the new upstream code
+
+          ## Failure Details
+
+          PROMPT_EOF
+
+          # Append failure details
+          cat ${GITHUB_WORKSPACE}/patch-failures.txt >> ${GITHUB_WORKSPACE}/claude-prompt.txt
+
+          cat >> ${GITHUB_WORKSPACE}/claude-prompt.txt << 'PROMPT_EOF'
+
+          ## Your Task
+
+          1. Read CLAUDE.md to understand how patches work in this repo
+          2. Read the failing patch file from _patches/
+          3. Examine the upstream source code in src/ to understand what changed
+          4. Update the patch file so it applies cleanly, following the
+             guidelines in CLAUDE.md about editing diff headers
+          5. Test your fix: ./_build/test-apply.sh --skip-tests <project>
+          6. If successful, stage and commit the patch update
+
+          ## Important Notes
+
+          - Only modify files in _patches/ directory
+          - When editing patches, update BOTH the diff content AND the
+            @@ header line counts in a single edit
+          - The patch may need line number adjustments if upstream added/removed lines
+          - Test your changes before committing
+          PROMPT_EOF
+
+          echo "Running Claude Code CLI..."
+          # Run Claude Code in headless mode with the prompt
+          # Using --dangerously-skip-permissions to allow file edits in CI
+          claude -p "$(cat ${GITHUB_WORKSPACE}/claude-prompt.txt)" \
+              --dangerously-skip-permissions \
+              --max-turns 20 \
+              --output-format text || true
+
+      - name: Verify Claude's fix
+        if: |
+          steps.test-patches.outputs.patches_failed == 'true' &&
+          steps.claude-check.outputs.claude_available == 'true'
+        id: verify-fix
+        run: |
+          . ${GITHUB_WORKSPACE}/_venv/bin/activate
+          cd ${GITHUB_WORKSPACE}/kerbside-patches
+
+          # Clean up any leftover source directories
+          rm -rf src/
+
+          # Re-run patch tests
+          set +e
+          ./_build/test-patches-for-ci.sh > ${GITHUB_WORKSPACE}/patch-verify-results.json 2>&1
+          verify_exit_code=$?
+          set -e
+
+          echo "Verification exit code: ${verify_exit_code}"
+          cat ${GITHUB_WORKSPACE}/patch-verify-results.json
+
+          if [ ${verify_exit_code} -eq 0 ]; then
+            echo "fix_succeeded=true" >> $GITHUB_OUTPUT
+          else
+            echo "fix_succeeded=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit Claude's patch fixes
+        if: |
+          steps.test-patches.outputs.patches_failed == 'true' &&
+          steps.claude-check.outputs.claude_available == 'true' &&
+          steps.verify-fix.outputs.fix_succeeded == 'true'
+        run: |
+          cd ${GITHUB_WORKSPACE}/kerbside-patches
+
+          # Check if there are changes to commit
+          if [ -n "$(git status --porcelain _patches/)" ]; then
+            git add _patches/
+            git commit -m "Auto-fix patches for daily rebase ${DATESTAMP}.
+
+            Claude Code automatically updated patches that failed to apply
+            after upstream SHA bump.
+
+            Assisted-By: Claude Code
+            Co-Authored-By: Claude <noreply@anthropic.com>"
+          fi
+
+      - name: Push branch and create PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.DAILY_REBASE_TOKEN }}
+        run: |
+          cd ${GITHUB_WORKSPACE}/kerbside-patches
+
+          git push -f origin daily-rebase-${DATESTAMP}
           sleep 10
-          echo
+
+          # Determine PR body based on what happened
+          if [ "${{ steps.test-patches.outputs.patches_failed }}" == "true" ]; then
+            if [ "${{ steps.verify-fix.outputs.fix_succeeded }}" == "true" ]; then
+              pr_body="A daily rebase was attempted.
+
+          **Note:** Some patches failed to apply with the new upstream SHAs.
+          Claude Code automatically fixed the patches.
+
+          Please review the patch changes carefully before merging."
+            else
+              pr_body="A daily rebase was attempted.
+
+          **Warning:** Some patches failed to apply and Claude Code was
+          unable to fix them automatically. Manual intervention is required.
+
+          See the workflow logs for details about which patches failed."
+            fi
+          else
+            pr_body="A daily rebase was attempted. All patches applied successfully."
+          fi
 
           echo "Create a PR..."
           gh pr create \
               --assignee mikalstill \
               --reviewer mikalstill \
-              --title "Daily rebase for ${datestamp}." \
-              --body "A daily rebase was attempted." \
+              --title "Daily rebase for ${DATESTAMP}." \
+              --body "${pr_body}" \
               --head $(git branch --show-current)
           echo
           echo "Pull request created."
+
+      - name: Create issue for unfixable patches
+        if: |
+          steps.test-patches.outputs.patches_failed == 'true' &&
+          (steps.claude-check.outputs.claude_available != 'true' ||
+           steps.verify-fix.outputs.fix_succeeded == 'false')
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.DAILY_REBASE_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const failuresPath = process.env.GITHUB_WORKSPACE + '/patch-failures.txt';
+            let failures = 'See workflow logs for details.';
+            try {
+              failures = fs.readFileSync(failuresPath, 'utf8');
+            } catch (e) {
+              console.log('Could not read failures file:', e);
+            }
+
+            const claudeAvailable = '${{ steps.claude-check.outputs.claude_available }}' === 'true';
+            const reason = claudeAvailable
+              ? 'Claude Code was unable to fix them automatically'
+              : 'Claude Code CLI was not available on the runner';
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Daily rebase failed: patches need manual attention (${process.env.DATESTAMP})`,
+              body: `The daily rebase workflow detected failing patches. ${reason}.
+
+            **Failed patches:**
+            \`\`\`
+            ${failures}
+            \`\`\`
+
+            Please review and fix manually. The daily rebase PR has been created but will fail CI until patches are fixed.
+
+            See [workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`,
+              labels: ['rebase-failure', 'needs-attention']
+            });

--- a/.github/workflows/daily-rebase-checks.yml
+++ b/.github/workflows/daily-rebase-checks.yml
@@ -35,10 +35,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.DAILY_REBASE_TOKEN }}
         run: |
-          python3 -mvenv ${GITHUB_WORKSPACE}/_venv
-          . ${GITHUB_WORKSPACE}/_venv/bin/activate
-          pip3 install yq
-
           cd ${GITHUB_WORKSPACE}/kerbside-patches
 
           git checkout -b daily-rebase-${DATESTAMP}
@@ -63,7 +59,6 @@ jobs:
         id: test-patches
         continue-on-error: true
         run: |
-          . ${GITHUB_WORKSPACE}/_venv/bin/activate
           cd ${GITHUB_WORKSPACE}/kerbside-patches
 
           # Run patch tests and capture results
@@ -162,7 +157,6 @@ jobs:
           steps.claude-check.outputs.claude_available == 'true'
         id: verify-fix
         run: |
-          . ${GITHUB_WORKSPACE}/_venv/bin/activate
           cd ${GITHUB_WORKSPACE}/kerbside-patches
 
           # Clean up any leftover source directories

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,9 @@ Located in `_patches/`:
 - `apply-patches-and-test.sh`: Applies patches from ORDER file, runs tests
 - `build-containers.sh`: Builds Kolla container images
 - `imagebuild.sh`: Container image build logic
+- `test-patches-for-ci.sh`: CI-friendly patch testing with JSON output
+- `extract-patch-failures.py`: Parse JSON failures into human-readable format
+- `bump-source-shas.sh`: Update source SHAs to latest upstream commits
 
 ### Tools (`tools/`)
 - `find_images`: GitLab Container Registry image finder (Python/Click CLI)
@@ -120,3 +123,56 @@ When editing `.patch` files in `_patches/`, you must update both the content AND
    - Kolla-Ansible runs `tox -elinters` which includes ansible-lint
 
 5. **Verify changes** by running `test-apply.sh` without `--skip-tests`
+
+## CI/CD Automation
+
+### Daily Rebase Workflow
+
+The `daily-rebase-checks.yml` workflow runs daily to:
+1. Update source SHAs to latest upstream commits
+2. Test if patches still apply cleanly
+3. If patches fail, invoke Claude Code to attempt automatic fixes
+4. Create a PR with the updated SHAs (and any auto-fixed patches)
+5. Create an issue if patches cannot be fixed automatically
+
+### Required Secrets
+
+- `DAILY_REBASE_TOKEN`: GitHub token for creating PRs and issues
+
+### Claude Code CLI
+
+The workflow uses the Claude Code CLI (`claude`) in headless mode for auto-fixing
+patches. This requires a dedicated runner with the `claude-code` label that has:
+
+1. Claude Code CLI pre-installed (`npm install -g @anthropic-ai/claude-code`)
+2. Pre-authenticated via `claude login` (uses Claude Max subscription)
+
+The runner must have valid credentials in `~/.claude/` for the user running jobs.
+
+### CI Scripts for Patch Testing
+
+```bash
+# Test all projects and output JSON results
+./_build/test-patches-for-ci.sh
+
+# Test specific projects
+./_build/test-patches-for-ci.sh kolla kolla-ansible
+
+# Parse failure output for human reading
+cat patch-results.json | ./_build/extract-patch-failures.py
+```
+
+The JSON output format:
+```json
+{
+  "success": false,
+  "projects_tested": ["kolla", "kolla-ansible"],
+  "failures": [
+    {
+      "project": "kolla",
+      "patch": "_patches/patch112-kolla-layer-data.patch",
+      "error": "error: patch failed: kolla/common/config.py:271..."
+    }
+  ]
+}
+```

--- a/_build/extract-patch-failures.py
+++ b/_build/extract-patch-failures.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Extract patch failure details from test-patches-for-ci.sh JSON output.
+
+Reads JSON from stdin and outputs human-readable failure details to stdout.
+Also writes a simplified failure summary suitable for Claude Code prompts.
+
+Usage:
+    cat patch-test-results.json | ./_build/extract-patch-failures.py
+
+Output format:
+    Project: kolla
+    Patch: _patches/patch112-kolla-layer-data.patch
+    Error: error: patch failed: kolla/common/config.py:271
+    ---
+"""
+
+import json
+import sys
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f'Error parsing JSON: {e}', file=sys.stderr)
+        sys.exit(1)
+
+    failures = data.get('failures', [])
+
+    if not failures:
+        print('No failures found.')
+        sys.exit(0)
+
+    for failure in failures:
+        project = failure.get('project', 'unknown')
+        patch = failure.get('patch', 'unknown')
+        error = failure.get('error', 'no error message')
+
+        print(f'Project: {project}')
+        print(f'Patch: {patch}')
+        print(f'Error: {error}')
+        print('---')
+
+
+if __name__ == '__main__':
+    main()

--- a/_build/test-patches-for-ci.sh
+++ b/_build/test-patches-for-ci.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+# Test patch application for all projects and output JSON results.
+# This script is designed for CI use - it captures failures in a structured
+# format that can be passed to Claude Code for auto-fixing.
+#
+# Usage: _build/test-patches-for-ci.sh [project1 project2 ...]
+#
+# If no projects specified, tests all projects with config.yaml files.
+# Outputs JSON to stdout with structure:
+# {
+#   "success": true/false,
+#   "projects_tested": [...],
+#   "failures": [
+#     {
+#       "project": "kolla",
+#       "patch": "_patches/patch112-kolla-layer-data.patch",
+#       "error": "error: patch failed: kolla/common/config.py:271..."
+#     }
+#   ]
+# }
+
+set -o pipefail
+
+topdir=$(pwd)
+topsrcdir="${topdir}/src"
+
+# Activate venv if available
+if [ -e /srv/shakenfist/kerbside-patches-tools/bin/activate ]; then
+    . /srv/shakenfist/kerbside-patches-tools/bin/activate
+fi
+
+# Determine which projects to test
+if [ $# -gt 0 ]; then
+    projects="$@"
+else
+    projects=$(find . -maxdepth 2 -name "config.yaml" -type f | \
+               cut -f 2 -d "/" | sort)
+fi
+
+# Initialize result tracking
+declare -a projects_tested=()
+declare -a failures=()
+overall_success=true
+
+# Helper to escape JSON strings
+json_escape() {
+    python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))"
+}
+
+for project in ${projects}; do
+    # Skip if no config.yaml
+    if [ ! -e "${project}/config.yaml" ]; then
+        continue
+    fi
+
+    projects_tested+=("\"${project}\"")
+
+    # Clean up any previous source directory
+    rm -rf "${topsrcdir}" 2>/dev/null || true
+
+    # Capture output from test-apply.sh
+    error_output=""
+    failed_patch=""
+
+    # Run test-apply.sh and capture output
+    output=$(./_build/apply-patches-and-test.sh --skip-tests "${project}" 2>&1)
+    exit_code=$?
+
+    if [ ${exit_code} -ne 0 ]; then
+        overall_success=false
+
+        # Extract the failing patch from output
+        # Look for lines like "Applying master ../_patches/patch112-kolla-layer-data.patch"
+        # followed by failure
+        failed_patch=$(echo "${output}" | \
+            grep -E "Applying.*_patches/.*\.patch" | \
+            tail -1 | \
+            sed -E 's/.*(_patches\/[^ ]+\.patch).*/\1/' | \
+            sed 's/\x1b\[[0-9;]*m//g')
+
+        # Extract error message (git apply output)
+        error_output=$(echo "${output}" | \
+            grep -A 20 "error: patch failed\|error: .*: patch does not apply" | \
+            head -25 | \
+            sed 's/\x1b\[[0-9;]*m//g')
+
+        # If no specific error found, get the last 30 lines
+        if [ -z "${error_output}" ]; then
+            error_output=$(echo "${output}" | tail -30 | sed 's/\x1b\[[0-9;]*m//g')
+        fi
+
+        # Escape for JSON
+        escaped_error=$(echo "${error_output}" | json_escape)
+        escaped_patch=$(echo "${failed_patch}" | tr -d '\n')
+
+        failures+=("{\"project\": \"${project}\", \"patch\": \"${escaped_patch}\", \"error\": ${escaped_error}}")
+    fi
+
+    # Clean up source directory to save space
+    rm -rf "${topsrcdir}" 2>/dev/null || true
+done
+
+# Build JSON output
+projects_json=$(IFS=,; echo "${projects_tested[*]}")
+failures_json=$(IFS=,; echo "${failures[*]}")
+
+cat <<EOF
+{
+  "success": ${overall_success},
+  "projects_tested": [${projects_json}],
+  "failures": [${failures_json}]
+}
+EOF
+
+# Exit with appropriate code
+if [ "${overall_success}" = true ]; then
+    exit 0
+else
+    exit 1
+fi


### PR DESCRIPTION
Extend the daily-rebase-checks.yml workflow to automatically attempt patch fixes when patches fail to apply after updating source SHAs. When patches fail, Claude Code is invoked to analyze the failure and update the patch files. If the fix succeeds, it's committed to the PR branch. If Claude cannot fix the patches, an issue is created for manual intervention.

New scripts:
- _build/test-patches-for-ci.sh: CI-friendly patch testing with JSON output capturing which patches failed and why
- _build/extract-patch-failures.py: Parse JSON failures into human-readable format for Claude Code prompts

Prompt: Add a step to the daily-rebase-checks.yml workflow that uses Claude Code to attempt rebases when applying patches fails.


Assisted-By: Claude Code