### PR TITLE
Add Gerrit analysis tools and pre-push linter.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,5 +16,5 @@ repos:
         name: shellcheck (extensionless scripts)
         files: ^(_build/|tools/)[^/.]+$
         types: [text]
-        exclude: '(find_images|spice-connect\.py|extract-commit-message|summarize_layers\.py|analyze-shared-patches\.py)$'
+        exclude: '(find_images|spice-connect\.py|extract-commit-message|summarize_layers\.py|analyze-shared-patches\.py|analyze-gerrit-new-roles|analyze-gerrit-patch-size|analyze-gerrit-review-times|gerrit-pre-push-lint)$'
         args: ['-x']

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,14 @@ Located in `_patches/`:
 - `find_images`: GitLab Container Registry image finder (Python/Click CLI)
 - `bootstrap-kolla-ansible`: Kolla-Ansible deployment helper
 - `test-console`: SPICE console testing utility
+- `gerrit-pre-push-lint`: Pre-push linter for OpenStack Gerrit submissions
+- `analyze-gerrit-review-times`: Analyzes review timestamps to find optimal posting times
+- `analyze-gerrit-patch-size`: Analyzes patch size/series length vs review response
+- `analyze-gerrit-new-roles`: Analyzes patterns for new Ansible role additions
+
+### Documentation (`docs/`)
+- `gerrit-api.md`: Reference guide for OpenStack Gerrit SSH and REST APIs
+- `tactics.md`: Tactical advice for getting patches reviewed quickly
 
 ## Key Configuration
 
@@ -129,6 +137,54 @@ When editing `.patch` files in `_patches/`, you must update both the content AND
    - Kolla-Ansible runs `tox -elinters` which includes ansible-lint
 
 5. **Verify changes** by running `test-apply.sh` without `--skip-tests`
+
+## Pre-Push Linting for OpenStack Gerrit
+
+The `gerrit-pre-push-lint` tool checks for common issues that reviewers typically
+flag during code review of Kolla and Kolla-Ansible patches. Run this before
+pushing to Gerrit to catch issues early.
+
+### Usage
+
+```bash
+# In an OpenStack project checkout (e.g., kolla-ansible)
+cd /path/to/kolla-ansible
+
+# Check staged changes (default)
+/path/to/kerbside-patches/tools/gerrit-pre-push-lint
+
+# Check all uncommitted changes
+gerrit-pre-push-lint --all
+
+# Check stacked patches (last N commits)
+gerrit-pre-push-lint --stack 5
+
+# Check commits in a range
+gerrit-pre-push-lint --range origin/master..HEAD
+
+# Check the most recent commit
+gerrit-pre-push-lint --commit
+```
+
+### Checks Performed
+
+Based on analysis of actual Gerrit review comments:
+
+1. **Release Notes**: Warns if code changes lack release notes (use `reno new`)
+2. **Bug References**: Suggests adding bug tracking for significant changes
+3. **Commit Message Quality**: Checks subject line length, "Trivial:" misuse
+4. **YAML Line Length**: Flags lines exceeding 160 characters
+5. **Ansible changed_when**: Warns about `changed_when: true` on read-only commands
+6. **Jinja2 Issues**: Catches spacing errors and typos in templates
+7. **TODO Comments**: Warns if TODOs lack release version targets
+8. **Depends-On Usage**: Warns when Depends-On references the same repository
+9. **File Modes**: Catches incorrect mode settings (e.g., 0644 on directories)
+
+### Severity Levels
+
+- **ERROR**: Must fix before pushing
+- **WARNING**: Should address before pushing
+- **INFO**: Optional improvements
 
 ## CI/CD Automation
 

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -241,6 +241,15 @@ directories. This section documents each script and its purpose.
 | `gather-logs` | Collects logs from Kolla containers for debugging. |
 | `spice-connect.py` | Python script for testing SPICE console connections programmatically. |
 
+### Pre-Push Linting for Gerrit
+
+| Script | Description |
+|--------|-------------|
+| `gerrit-pre-push-lint` | Pre-push linter for OpenStack Gerrit submissions. Checks for common issues that reviewers flag during code review (missing release notes, bug references, YAML line length, Jinja2 issues, etc.). Supports checking stacked patches with `--stack N` or `--range origin/master..HEAD`. |
+| `analyze-gerrit-review-times` | Analyzes Gerrit review timestamps to find optimal posting times. Fetches recent merged reviews and shows when reviewers are most active by hour and day of week. |
+| `analyze-gerrit-patch-size` | Analyzes correlation between patch size, series length, and review response. Shows how patch complexity affects time to review, merge, and number of revision cycles needed. |
+| `analyze-gerrit-new-roles` | Analyzes historical patterns for new Ansible role additions. Shows successful strategies, series vs standalone patterns, and recommendations for getting new roles merged. |
+
 ### Certificate and Network Configuration
 
 | Script | Description |
@@ -283,3 +292,10 @@ The configured hooks include:
 | `extract-commit-message` | Extracts commit messages from patch files. |
 | `find_changes` | Lists changed files for review. |
 | `upgrade-python` | Helper for upgrading Python dependencies. |
+
+## Documentation (`docs/`)
+
+| Document | Description |
+|----------|-------------|
+| `gerrit-api.md` | Reference guide for interacting with the OpenStack Gerrit instance at review.opendev.org. Covers both SSH API (for querying changes) and REST API (for fetching inline comments). Includes examples for batch fetching reviews and analyzing feedback patterns. |
+| `tactics.md` | Tactical advice for getting Kolla/Kolla-Ansible patches reviewed quickly. Based on analysis of reviewer activity patterns - optimal posting times, peak days, key reviewers and their timezones. |

--- a/docs/gerrit-api.md
+++ b/docs/gerrit-api.md
@@ -1,0 +1,360 @@
+# Gerrit API Reference for OpenStack Development
+
+This document describes how to interact with the OpenStack Gerrit instance at
+`review.opendev.org` using both SSH and REST APIs. This information was gathered
+while building the `gerrit-pre-push-lint` tool.
+
+## SSH API
+
+The SSH API provides access to Gerrit commands over SSH on port 29418.
+
+### Authentication
+
+You need an SSH key registered with your Gerrit account. Register keys at:
+https://review.opendev.org/settings/#SSHKeys
+
+### Basic Connection
+
+```bash
+ssh -p 29418 review.opendev.org gerrit --help
+```
+
+### Available Commands
+
+Key commands for review analysis:
+
+| Command | Description |
+|---------|-------------|
+| `query` | Query the change database |
+| `review` | Apply reviews to patch sets |
+| `ls-projects` | List visible projects |
+| `stream-events` | Monitor events in real-time |
+
+### Query Command
+
+The `query` command is the most useful for gathering review data.
+
+```bash
+ssh -p 29418 review.opendev.org gerrit query [OPTIONS] QUERY
+```
+
+#### Query Options
+
+| Option | Description |
+|--------|-------------|
+| `--format [TEXT\|JSON]` | Output format (JSON recommended for parsing) |
+| `--comments` | Include patch set and inline comments |
+| `--current-patch-set` | Include current patch set info |
+| `--all-approvals` | Include all patch set approvals |
+| `--all-reviewers` | Include all reviewers |
+| `--commit-message` | Include full commit message |
+| `--files` | Include file list on patch sets |
+| `--dependencies` | Include depends-on/needed-by info |
+| `--patch-sets` | Include all patch set info |
+| `--submit-records` | Include submit and label status |
+| `--no-limit` | Return all results (default limit applies otherwise) |
+| `--start N` | Skip first N results (for pagination) |
+
+#### Query Syntax
+
+Queries use Gerrit's search syntax:
+
+```bash
+# Find merged changes in a project
+project:openstack/kolla status:merged
+
+# Find open changes by author
+project:openstack/kolla-ansible owner:username status:open
+
+# Find changes with specific topic
+topic:debian-add-spice-package
+
+# Find changes modified after a date
+project:openstack/kolla after:2024-01-01
+
+# Combine with limit
+project:openstack/kolla status:merged limit:50
+```
+
+#### Example: Fetch Recent Merged Reviews with Comments
+
+```bash
+ssh -p 29418 review.opendev.org gerrit query \
+    --format=JSON \
+    --comments \
+    --current-patch-set \
+    'project:openstack/kolla status:merged limit:20'
+```
+
+#### JSON Output Structure
+
+Each change is output as a single JSON line:
+
+```json
+{
+  "project": "openstack/kolla",
+  "branch": "master",
+  "id": "Ib4ced4a04353b9c11c6f0abb7cfa91001b239e53",
+  "number": 972441,
+  "subject": "Re-enable SPICE support on Debian.",
+  "owner": {
+    "name": "Michael Still",
+    "email": "mikal@stillhq.com",
+    "username": "mikalstill"
+  },
+  "url": "https://review.opendev.org/c/openstack/kolla/+/972441",
+  "status": "MERGED",
+  "comments": [
+    {
+      "timestamp": 1767779873,
+      "reviewer": {"name": "...", "username": "..."},
+      "message": "Uploaded patch set 1."
+    }
+  ],
+  "currentPatchSet": {
+    "number": 4,
+    "approvals": [
+      {"type": "Code-Review", "value": "2", "by": {...}}
+    ]
+  }
+}
+```
+
+The final line contains statistics:
+
+```json
+{"type": "stats", "rowCount": 20, "runTimeMilliseconds": 45, "moreChanges": true}
+```
+
+**Note**: The `comments` field from the SSH API contains patch-set-level messages
+(uploads, votes, general comments) but NOT inline code comments. For inline
+comments, use the REST API.
+
+## REST API
+
+The REST API provides more detailed data, particularly inline code comments.
+
+### Base URL
+
+```
+https://review.opendev.org/
+```
+
+### Response Format
+
+REST API responses are prefixed with `)]}'` to prevent JSON hijacking. Strip
+this before parsing:
+
+```bash
+curl -s 'https://review.opendev.org/changes/...' | tail -c +5 | jq .
+```
+
+Or in Python:
+
+```python
+import requests
+import json
+
+response = requests.get('https://review.opendev.org/changes/...')
+data = json.loads(response.text[4:])  # Skip ")]}'" prefix
+```
+
+### Endpoints
+
+#### List Changes
+
+```
+GET /changes/?q=QUERY&n=LIMIT&o=OPTIONS
+```
+
+Query parameters:
+- `q`: Search query (same syntax as SSH)
+- `n`: Number of results
+- `o`: Additional data to include (can be repeated)
+
+Option values for `o`:
+- `CURRENT_REVISION` - Include current revision info
+- `ALL_REVISIONS` - Include all revisions
+- `MESSAGES` - Include change messages
+- `DETAILED_LABELS` - Include detailed label info
+- `DETAILED_ACCOUNTS` - Include account details
+- `CURRENT_COMMIT` - Include current commit info
+- `ALL_COMMITS` - Include all commits
+- `CURRENT_FILES` - Include file list for current revision
+- `ALL_FILES` - Include file list for all revisions
+
+Example:
+
+```bash
+curl -s 'https://review.opendev.org/changes/?q=project:openstack/kolla+status:merged&n=5&o=CURRENT_REVISION&o=MESSAGES&o=DETAILED_LABELS'
+```
+
+#### Get Inline Comments
+
+This is the key endpoint for analyzing code review feedback:
+
+```
+GET /changes/{change-id}/comments
+```
+
+Example:
+
+```bash
+curl -s 'https://review.opendev.org/changes/972441/comments'
+```
+
+Response structure (keyed by file path):
+
+```json
+{
+  "/COMMIT_MSG": [
+    {
+      "author": {
+        "_account_id": 13252,
+        "name": "Dr. Jens Harbott",
+        "email": "frickler@offenerstapel.de"
+      },
+      "patch_set": 3,
+      "line": 21,
+      "range": {
+        "start_line": 21,
+        "start_character": 24,
+        "end_line": 21,
+        "end_character": 70
+      },
+      "message": "the pkgs doesn't exist for bookworm...",
+      "unresolved": true
+    }
+  ],
+  "/PATCHSET_LEVEL": [...],
+  "releasenotes/notes/file.yaml": [...]
+}
+```
+
+Special file paths:
+- `/COMMIT_MSG` - Comments on the commit message
+- `/PATCHSET_LEVEL` - General comments not attached to a specific file
+
+#### Get Change Detail
+
+```
+GET /changes/{change-id}/detail
+```
+
+Returns comprehensive change information including messages, labels, and
+reviewers.
+
+#### Get Specific Revision
+
+```
+GET /changes/{change-id}/revisions/{revision-id}/review
+```
+
+Where `revision-id` can be a commit SHA or `current`.
+
+## Common Patterns for Review Analysis
+
+### Fetching Reviews with Multiple Patch Sets
+
+Reviews with multiple patch sets indicate feedback was given. Query for these:
+
+```bash
+# SSH: Get reviews and check currentPatchSet.number > 1
+ssh -p 29418 review.opendev.org gerrit query \
+    --format=JSON \
+    --current-patch-set \
+    'project:openstack/kolla-ansible status:merged limit:50'
+```
+
+Then filter in your code for `currentPatchSet.number > 1`.
+
+### Getting Detailed Inline Comments
+
+For each interesting change number, fetch inline comments:
+
+```bash
+curl -s "https://review.opendev.org/changes/${change_number}/comments"
+```
+
+### Identifying Review Patterns
+
+Common patterns found in Kolla/Kolla-Ansible reviews:
+
+1. **Release Notes**: Look for comments mentioning "release note", "reno"
+2. **Bug References**: Comments suggesting "bug report", "launchpad"
+3. **Code Style**: Comments about "line length", "spacing", "formatting"
+4. **Ansible Issues**: Comments about "changed_when", "name[missing]"
+5. **Documentation**: Comments about wording, terminology
+
+### Rate Limiting
+
+The OpenStack Gerrit instance does not appear to have aggressive rate limiting,
+but be respectful:
+
+- Add delays between requests when fetching many changes
+- Cache responses when possible
+- Use the `limit` parameter to fetch only what you need
+
+## Example: Batch Fetching Reviews
+
+```python
+#!/usr/bin/env python3
+"""Example script to fetch and analyze Gerrit reviews."""
+
+import json
+import subprocess
+import requests
+import time
+
+def fetch_reviews_ssh(project: str, limit: int = 50) -> list:
+    """Fetch reviews via SSH API."""
+    cmd = [
+        'ssh', '-p', '29418', 'review.opendev.org',
+        'gerrit', 'query',
+        '--format=JSON',
+        '--comments',
+        '--current-patch-set',
+        f'project:{project} status:merged limit:{limit}'
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    reviews = []
+    for line in result.stdout.strip().split('\n'):
+        data = json.loads(line)
+        if data.get('type') != 'stats':
+            reviews.append(data)
+    return reviews
+
+def fetch_inline_comments(change_number: int) -> dict:
+    """Fetch inline comments via REST API."""
+    url = f'https://review.opendev.org/changes/{change_number}/comments'
+    response = requests.get(url)
+    return json.loads(response.text[4:])  # Skip ")]}'"
+
+def analyze_reviews(project: str):
+    """Analyze reviews for common feedback patterns."""
+    reviews = fetch_reviews_ssh(project)
+
+    for review in reviews:
+        # Only look at reviews with multiple patch sets
+        if review.get('currentPatchSet', {}).get('number', 1) > 1:
+            change_num = review['number']
+            print(f"Analyzing {review['subject']} (#{change_num})")
+
+            comments = fetch_inline_comments(change_num)
+            for filepath, file_comments in comments.items():
+                for comment in file_comments:
+                    print(f"  {filepath}: {comment['message'][:80]}...")
+
+            time.sleep(0.5)  # Be nice to the server
+
+if __name__ == '__main__':
+    analyze_reviews('openstack/kolla-ansible')
+```
+
+## References
+
+- [Gerrit REST API Documentation](https://gerrit-review.googlesource.com/Documentation/rest-api.html)
+- [Gerrit SSH Command Reference](https://gerrit-review.googlesource.com/Documentation/cmd-index.html)
+- [OpenDev Gerrit Instance](https://review.opendev.org/)
+- [Gerrit Query Syntax](https://gerrit-review.googlesource.com/Documentation/user-search.html)

--- a/docs/tactics.md
+++ b/docs/tactics.md
@@ -1,0 +1,258 @@
+# Gerrit Review Tactics for Kolla / Kolla-Ansible
+
+This document provides tactical advice for getting your patches reviewed quickly
+in the Kolla and Kolla-Ansible projects. Based on analysis of 200 recent merged
+reviews using the `analyze-gerrit-review-times` tool.
+
+## When to Post Changes
+
+### Peak Review Hours (UTC)
+
+| Hour (UTC) | Activity Level | Notes |
+|------------|----------------|-------|
+| 09:00 | **Highest** (254 activities) | European morning |
+| 12:00 | Very High (195) | European lunch / Asia evening |
+| 10:00 | High (187) | |
+| 14:00 | High (177) | European afternoon |
+| 08:00 | High (173) | European start of day |
+
+Review activity is minimal from 22:00-04:00 UTC.
+
+### Peak Review Days
+
+| Day | Activity Level | Recommendation |
+|-----|----------------|----------------|
+| Thursday | **Highest** (582 activities) | Best day to post |
+| Friday | High (413) | Good, but less time for iteration |
+| Monday | High (403) | Good |
+| Wednesday | Moderate (374) | Acceptable |
+| Tuesday | Moderate (358) | Acceptable |
+| Saturday | Low (59) | Avoid |
+| Sunday | Very Low (33) | Avoid |
+
+### Key Reviewers and Their Timezones
+
+The Kolla/Kolla-Ansible core reviewers are distributed globally:
+
+| Reviewer | Reviews | Peak Hour (UTC) | Likely Timezone |
+|----------|---------|-----------------|-----------------|
+| Michal Nasiadka | 1291 | 08:00 | Central Europe (UTC+1) |
+| Maksim Malchuk | 274 | 16:00 | UTC+7 (e.g., Bangkok) |
+| Bartosz Bezak | 216 | 09:00 | Central Europe |
+| Dr. Jens Harbott | 111 | 19:00 | UTC+10 (e.g., Sydney) |
+| Bertrand Lanson | 91 | 20:00 | UTC+11 |
+
+Michal Nasiadka is by far the most active reviewer, accounting for ~60% of all
+review activity. Posting when he starts his day (08:00-09:00 UTC) is strategic.
+
+## Time to First Review
+
+- **Median**: 1.6 hours
+- **25th percentile**: 0.3 hours (many reviews get quick attention)
+- **75th percentile**: 8.5 hours
+- **Average**: 64.8 hours (skewed by some long-waiting reviews)
+
+Most patches get initial feedback within a few hours if posted during peak
+activity times.
+
+## Optimal Posting Strategy
+
+### By Your Timezone
+
+| Your Timezone | Optimal Local Time | Why |
+|---------------|-------------------|-----|
+| US Pacific (PST/PDT) | 01:00 (night before) | Catches European morning |
+| US Eastern (EST/EDT) | 04:00-05:00 | Catches European morning |
+| Europe/Berlin (CET) | 09:00-10:00 | Peak activity time |
+| Australia/Sydney (AEST) | 19:00-20:00 | Catches European morning next day |
+
+### General Strategy
+
+1. **Post on Thursday morning (European time)** - This maximizes:
+   - European reviewers see it during their workday
+   - Asia-Pacific reviewers see it in their afternoon/evening
+   - Full workweek remaining for iteration
+
+2. **Respond to feedback quickly** - The 1.6 hour median time to first review
+   means you can often iterate same-day if you're responsive
+
+3. **Avoid weekends** - Activity drops by ~90%, your patch will sit
+
+4. **Friday afternoon is risky** - You may get feedback but no time to address
+   it before the weekend lull
+
+## Common Review Feedback (Pre-emptive Checklist)
+
+Before posting, check these common issues (see `gerrit-pre-push-lint` tool):
+
+- [ ] **Release notes** - Add for user-visible changes (`reno new <slug>`)
+- [ ] **Bug reference** - Add `Closes-Bug: #NNNN` for non-trivial fixes
+- [ ] **Commit message** - Subject ≤50 chars ideal, ≤72 max
+- [ ] **YAML line length** - Keep under 160 characters
+- [ ] **Ansible changed_when** - Use `false` for read-only commands
+- [ ] **Jinja2 spacing** - `{{ variable }}` not `{{variable}}`
+- [ ] **TODO comments** - Include release target: `TODO(user): Remove in 2026.1`
+
+## Building Reviewer Relationships
+
+Some observations from the data:
+
+1. **Consistent reviewers** - The same core team reviews most patches. Building
+   rapport with them through quality submissions helps long-term.
+
+2. **Quick iteration** - Reviewers appreciate authors who respond promptly to
+   feedback. This builds trust for future reviews.
+
+3. **Clean submissions** - Running linters and tests before posting shows
+   respect for reviewer time.
+
+## Patch Size and Series Length
+
+Analysis of 300 reviews reveals how patch size and series length affect reviews.
+
+### Patch Size Impact
+
+| Size (lines) | Count | Med. Revisions | Med. Hrs to Review | Med. Hrs to Merge |
+|--------------|-------|----------------|-------------------|-------------------|
+| Small (11-50) | 205 | 1 | 1.5 | 26.0 |
+| Medium (51-200) | 83 | 1 | 8.4 | 24.3 |
+| Large (201-500) | 8 | 51 | 1.6 | 353.6 |
+| Huge (500+) | 4 | 21 | 1.9 | 1851.8 |
+
+**Key findings:**
+- **Small patches merge fastest** (26 hours median)
+- **Large patches take 14x longer to merge** despite getting reviewed quickly
+- **Large patches need ~50 revision cycles** vs 1 for small patches
+
+### Series vs Standalone Patches
+
+| Type | Count | Avg. Revisions | Med. Hrs to Review | Med. Hrs to Merge |
+|------|-------|----------------|-------------------|-------------------|
+| Standalone | 273 | 4.0 | 6.8 | 25.1 |
+| In a series | 27 | 18.4 | 0.7 | 119.0 |
+
+**Key findings:**
+- **Series get first review 6x FASTER** (0.7 vs 6.8 hours)
+- **But series take 5x LONGER to merge** (119 vs 25 hours)
+- **Series need 4.5x MORE revisions** on average
+
+### Why Series Get Reviewed Faster
+
+Series patches get quicker initial reviews likely because:
+1. Reviewers see related context and understand the bigger picture
+2. Topics help reviewers find all related patches
+3. Active series indicate engaged contributors
+
+### Why Series Take Longer to Merge
+
+Despite faster initial reviews, series take longer because:
+1. **All patches must be ready** - one blocker holds up the chain
+2. **Iteration cycles compound** - changes ripple through the series
+3. **Reviewer attention** - harder to get multiple +2s across all patches
+
+### Recommendations: Size and Series
+
+1. **Keep patches small** (under 50 lines ideal)
+   - 1 revision cycle vs 50+ for large patches
+   - 26 hours to merge vs 350+ hours
+
+2. **Break large changes into series** but understand the tradeoff:
+   - You'll get reviewed faster
+   - But merging takes longer (all patches must pass together)
+
+3. **If you must submit a large patch:**
+   - Expect many revision cycles
+   - Be very responsive to feedback
+   - Consider if it can be broken up
+
+4. **Series strategy:**
+   - 2-3 patches is the sweet spot
+   - Longer series (5+) have higher merge times
+   - Make each patch independently reviewable if possible
+
+5. **For urgent changes:**
+   - Standalone small patches merge fastest (25 hours)
+   - Avoid series if time-sensitive
+
+## New Ansible Role Additions
+
+Analysis of 186 new role/service additions reveals different patterns than
+general patches.
+
+### The Counterintuitive Finding
+
+For new roles, **standalone patches are MORE successful than series**:
+
+| Approach | Count | Median Revisions | Median Days to Merge |
+|----------|-------|------------------|---------------------|
+| Standalone | 156 | 2 | 9.0 |
+| In a series | 30 | 17 | 60.6 |
+
+Series take **7x longer** and need **8x more revisions** for new role additions!
+
+### Why Standalone Works Better for New Roles
+
+1. **Reviewers can see the complete picture** - A role is a cohesive unit
+2. **No coordination overhead** - Series require all patches to be ready
+3. **Simpler iteration** - Fix feedback in one place, not across patches
+4. **Atomic functionality** - Either the role works or it doesn't
+
+### Successful Large Additions (Real Examples)
+
+These 200+ line additions merged quickly as standalone patches:
+
+| Change | Lines | Revisions | Days |
+|--------|-------|-----------|------|
+| rabbitmq: Add stream queues support | 201 | 2 | 5.1 |
+| Add docker_image_name_prefix support | 354 | 3 | 32.9 |
+
+### When Series DO Make Sense for Roles
+
+Series work when patches are **genuinely independent**:
+
+1. **Cross-project dependencies** (Kolla image + Kolla-Ansible role)
+2. **Shared infrastructure** (Add base capability, then use it in role)
+3. **Phased rollout** (Add disabled feature, then enable in follow-up)
+
+Example: `kolla_uwsgi` series (16 patches) added uWSGI support to multiple
+services - each service was independent, so parallel review worked.
+
+### Recommended Approach for New Roles
+
+1. **Submit as a single cohesive patch** (even if 200-400 lines)
+2. **Follow existing role structure exactly** - Reviewers spot deviations fast
+3. **Include everything in one patch:**
+   - Role tasks, handlers, templates, defaults
+   - Documentation updates
+   - Release note
+4. **Expect 3-8 revision cycles** - This is normal for new roles
+5. **Be very responsive** to feedback - Quick iteration builds trust
+
+### Pre-Submission Checklist for New Roles
+
+- [ ] Matches structure of similar existing roles
+- [ ] Comprehensive defaults in `defaults/main.yml`
+- [ ] Documentation in `doc/source/reference/`
+- [ ] Release note added
+- [ ] Tested with actual deployment (if possible)
+- [ ] Bug/blueprint reference in commit message
+- [ ] Run `tox -elinters` locally first
+
+## Running Your Own Analysis
+
+To analyze current patterns (data changes over time):
+
+```bash
+# Review timing patterns
+./tools/analyze-gerrit-review-times
+
+# Patch size and series analysis
+./tools/analyze-gerrit-patch-size
+
+# More data for better accuracy
+./tools/analyze-gerrit-review-times --limit 200
+./tools/analyze-gerrit-patch-size --limit 200
+
+# Analyze a different project
+./tools/analyze-gerrit-review-times --project openstack/nova --limit 100
+```

--- a/tools/analyze-gerrit-new-roles
+++ b/tools/analyze-gerrit-new-roles
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""
+Analyze how new Ansible role additions are structured and reviewed.
+
+This script examines historical patterns for adding new roles/services to
+Kolla-Ansible to identify successful strategies.
+
+Usage:
+    analyze-gerrit-new-roles              # Analyze recent role additions
+    analyze-gerrit-new-roles --limit 300  # Analyze more history
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import defaultdict
+
+
+def fetch_reviews(project: str, limit: int) -> list:
+    """Fetch role-related reviews from Gerrit."""
+    cmd = [
+        'ssh', '-p', '29418', 'review.opendev.org',
+        'gerrit', 'query',
+        '--format=JSON',
+        '--comments',
+        '--current-patch-set',
+        '--commit-message',
+        f'project:{project} status:merged '
+        '(subject:"Add" OR subject:"new" OR subject:"Introduce" '
+        'OR subject:"role" OR subject:"service") '
+        f'limit:{limit}'
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f'Error: {result.stderr}', file=sys.stderr)
+        return []
+
+    reviews = []
+    for line in result.stdout.strip().split('\n'):
+        if line:
+            data = json.loads(line)
+            if data.get('type') != 'stats':
+                subject = data.get('subject', '').lower()
+                # Filter for role-related changes
+                if 'role' in subject or 'service' in subject or 'add ' in subject:
+                    reviews.append(data)
+    return reviews
+
+
+def analyze_reviews(reviews: list):
+    """Analyze role addition patterns."""
+    # Categorize by type
+    new_roles = []
+
+    for r in reviews:
+        subject = r.get('subject', '').lower()
+        if any(x in subject for x in ['add ', 'introduce', 'new ', 'initial']):
+            new_roles.append(r)
+
+    return new_roles
+
+
+def print_results(new_roles: list):
+    """Print analysis results."""
+    print('=' * 70)
+    print('NEW ROLE/SERVICE ADDITIONS (Recent Examples)')
+    print('=' * 70)
+
+    # Show recent examples
+    for r in sorted(new_roles, key=lambda x: -x.get('lastUpdated', 0))[:15]:
+        subject = r.get('subject', '')
+        ps = r.get('currentPatchSet', {})
+        ps_num = ps.get('number', 1)
+        insertions = ps.get('sizeInsertions', 0)
+        deletions = abs(ps.get('sizeDeletions', 0))
+        total = insertions + deletions
+
+        created = r.get('createdOn', 0)
+        merged = r.get('lastUpdated', 0)
+        days_to_merge = (merged - created) / 86400 if created and merged else 0
+
+        topic = r.get('topic', 'none')
+        url = r.get('url', '')
+
+        print(f'\n{subject[:65]}')
+        print(f'  Lines: +{insertions}/-{deletions} ({total} total)')
+        print(f'  Patch sets: {ps_num}, Days to merge: {days_to_merge:.1f}')
+        print(f'  Topic: {topic}')
+        print(f'  URL: {url}')
+
+    # Calculate stats
+    print('\n' + '=' * 70)
+    print('STATISTICS FOR NEW ROLE ADDITIONS')
+    print('=' * 70)
+
+    if new_roles:
+        sizes = []
+        patchsets = []
+        days = []
+
+        for r in new_roles:
+            ps = r.get('currentPatchSet', {})
+            sizes.append(
+                ps.get('sizeInsertions', 0) + abs(ps.get('sizeDeletions', 0))
+            )
+            patchsets.append(ps.get('number', 1))
+
+            created = r.get('createdOn', 0)
+            merged = r.get('lastUpdated', 0)
+            if created and merged:
+                days.append((merged - created) / 86400)
+
+        sizes.sort()
+        patchsets.sort()
+        days.sort()
+
+        n = len(new_roles)
+        print(f'Sample size: {n} reviews')
+        print(f'\nPatch size (lines changed):')
+        print(f'  Median: {sizes[n//2]}')
+        print(f'  Min: {min(sizes)}, Max: {max(sizes)}')
+        print(f'  Average: {sum(sizes)/n:.0f}')
+
+        print(f'\nPatch sets needed:')
+        print(f'  Median: {patchsets[n//2]}')
+        print(f'  Min: {min(patchsets)}, Max: {max(patchsets)}')
+        print(f'  Average: {sum(patchsets)/n:.1f}')
+
+        if days:
+            dn = len(days)
+            print(f'\nDays to merge:')
+            print(f'  Median: {days[dn//2]:.1f}')
+            print(f'  Min: {min(days):.1f}, Max: {max(days):.1f}')
+            print(f'  Average: {sum(days)/dn:.1f}')
+
+    # Series patterns
+    print('\n' + '=' * 70)
+    print('SERIES VS STANDALONE PATTERNS')
+    print('=' * 70)
+
+    topics = defaultdict(list)
+    for r in new_roles:
+        topic = r.get('topic', '')
+        if topic:
+            topics[topic].append(r)
+
+    series_count = sum(
+        1 for r in new_roles
+        if r.get('topic') and len(topics.get(r.get('topic', ''), [])) > 1
+    )
+    standalone_count = len(new_roles) - series_count
+
+    print(f'\nStandalone new roles: {standalone_count}')
+    print(f'New roles in series: {series_count}')
+
+    # Calculate metrics for each group
+    standalone = [
+        r for r in new_roles
+        if not r.get('topic') or len(topics.get(r.get('topic', ''), [])) == 1
+    ]
+    in_series = [
+        r for r in new_roles
+        if r.get('topic') and len(topics.get(r.get('topic', ''), [])) > 1
+    ]
+
+    for name, group in [('Standalone', standalone), ('In series', in_series)]:
+        if group:
+            ps_nums = [
+                r.get('currentPatchSet', {}).get('number', 1) for r in group
+            ]
+            merge_days = []
+            for r in group:
+                created = r.get('createdOn', 0)
+                merged = r.get('lastUpdated', 0)
+                if created and merged:
+                    merge_days.append((merged - created) / 86400)
+
+            ps_nums.sort()
+            merge_days.sort()
+            print(f'\n{name} ({len(group)} reviews):')
+            print(f'  Median patch sets: {ps_nums[len(ps_nums)//2]}')
+            if merge_days:
+                print(f'  Median days to merge: {merge_days[len(merge_days)//2]:.1f}')
+
+    # Show series examples
+    series_roles = [(t, rs) for t, rs in topics.items() if len(rs) > 1]
+    if series_roles:
+        print(f'\nExample series containing new roles:')
+        for topic, rs in sorted(series_roles, key=lambda x: -len(x[1]))[:5]:
+            print(f'\n  Topic: {topic} ({len(rs)} patches)')
+            for r in rs[:3]:
+                subj = r.get('subject', '')[:50]
+                ps = r.get('currentPatchSet', {})
+                ins = ps.get('sizeInsertions', 0)
+                print(f'    - {subj}... (+{ins})')
+            if len(rs) > 3:
+                print(f'    ... and {len(rs) - 3} more')
+
+    # Success patterns
+    print('\n' + '=' * 70)
+    print('SUCCESSFUL STRATEGIES (Large additions that merged smoothly)')
+    print('=' * 70)
+
+    quick_large = []
+    for r in new_roles:
+        ps = r.get('currentPatchSet', {})
+        size = ps.get('sizeInsertions', 0) + abs(ps.get('sizeDeletions', 0))
+        ps_num = ps.get('number', 1)
+
+        created = r.get('createdOn', 0)
+        merged = r.get('lastUpdated', 0)
+        days_to_merge = (merged - created) / 86400 if created and merged else 999
+
+        # Large (>200 lines) but merged in <60 days with few revisions
+        if size > 200 and days_to_merge < 60 and ps_num <= 6:
+            quick_large.append((r, size, ps_num, days_to_merge))
+
+    if quick_large:
+        print(
+            f'\nLarge additions (>200 lines) merged in <60 days '
+            f'with ≤6 revisions:'
+        )
+        for r, size, ps_num, days_merge in sorted(quick_large, key=lambda x: x[3])[:8]:
+            subject = r.get('subject', '')[:55]
+            topic = r.get('topic', '')
+            strategy = 'series' if topic else 'standalone'
+            print(f'\n  {subject}')
+            print(f'    {size} lines, {ps_num} revisions, {days_merge:.1f} days')
+            print(f'    Strategy: {strategy}')
+            if topic:
+                print(f'    Topic: {topic}')
+    else:
+        print('\nNo examples found matching criteria.')
+
+    print('\n' + '=' * 70)
+    print('RECOMMENDATIONS FOR NEW ROLE ADDITIONS')
+    print('=' * 70)
+    print('''
+Based on historical patterns:
+
+1. **Most new roles are submitted as standalone patches**
+   - Simpler to review as a complete unit
+   - Avoids coordination overhead of series
+
+2. **Expect multiple revision cycles**
+   - New roles typically need 3-8 patch sets
+   - Plan for iteration, especially on first submission
+
+3. **Breaking up a new role (when it makes sense):**
+   - Patch 1: Schema/config changes (globals.yml additions)
+   - Patch 2: Docker image definitions (if in Kolla)
+   - Patch 3: Ansible role (tasks, handlers, templates)
+   - Patch 4: Documentation updates
+
+4. **What reviewers look for in new roles:**
+   - Consistent structure with existing roles
+   - Proper defaults and documentation
+   - Integration with existing services
+   - Release notes
+
+5. **Pre-submission checklist:**
+   - [ ] Follow existing role structure exactly
+   - [ ] Include comprehensive defaults
+   - [ ] Add documentation in doc/source/
+   - [ ] Include release note
+   - [ ] Test with actual deployment if possible
+   - [ ] Reference any related specs/blueprints
+''')
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Analyze Gerrit patterns for new role additions',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        '--limit', '-n',
+        type=int,
+        default=300,
+        help='Number of reviews to search (default: 300)',
+    )
+    parser.add_argument(
+        '--project', '-p',
+        default='openstack/kolla-ansible',
+        help='Project to analyze (default: openstack/kolla-ansible)',
+    )
+
+    args = parser.parse_args()
+
+    print(f'Fetching role-related reviews from {args.project}...')
+    reviews = fetch_reviews(args.project, args.limit)
+
+    if not reviews:
+        print('No role-related reviews found.')
+        sys.exit(1)
+
+    print(f'Found {len(reviews)} role/service related reviews\n')
+
+    new_roles = analyze_reviews(reviews)
+    print(f'Identified {len(new_roles)} new role/service additions\n')
+
+    if new_roles:
+        print_results(new_roles)
+    else:
+        print('No new role additions found in the results.')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/analyze-gerrit-patch-size
+++ b/tools/analyze-gerrit-patch-size
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""
+Analyze correlation between patch size/series length and review response.
+
+This script examines whether smaller patches or shorter series get reviewed
+faster or with fewer revision cycles.
+
+Usage:
+    analyze-gerrit-patch-size              # Analyze last 100 reviews
+    analyze-gerrit-patch-size --limit 200  # Analyze more reviews
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+
+
+def fetch_reviews(project: str, limit: int) -> list:
+    """Fetch reviews from Gerrit via SSH API."""
+    cmd = [
+        'ssh', '-p', '29418', 'review.opendev.org',
+        'gerrit', 'query',
+        '--format=JSON',
+        '--comments',
+        '--current-patch-set',
+        '--dependencies',
+        f'project:{project} status:merged limit:{limit}'
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f'Error fetching from {project}: {result.stderr}', file=sys.stderr)
+        return []
+
+    reviews = []
+    for line in result.stdout.strip().split('\n'):
+        if line:
+            data = json.loads(line)
+            if data.get('type') != 'stats':
+                reviews.append(data)
+    return reviews
+
+
+def get_series_info(reviews: list) -> dict:
+    """Group reviews by topic to identify series."""
+    topics = defaultdict(list)
+    for review in reviews:
+        topic = review.get('topic', '')
+        if topic:
+            topics[topic].append(review)
+    return topics
+
+
+def analyze_reviews(reviews: list):
+    """Analyze patch size and series correlations."""
+    # Categorize by size
+    size_buckets = {
+        'tiny': {'range': (0, 10), 'reviews': []},
+        'small': {'range': (11, 50), 'reviews': []},
+        'medium': {'range': (51, 200), 'reviews': []},
+        'large': {'range': (201, 500), 'reviews': []},
+        'huge': {'range': (501, float('inf')), 'reviews': []},
+    }
+
+    # Group by topic for series analysis
+    topics = get_series_info(reviews)
+    standalone_reviews = []
+    series_reviews = []
+
+    for review in reviews:
+        # Get patch size
+        ps = review.get('currentPatchSet', {})
+        insertions = ps.get('sizeInsertions', 0)
+        deletions = abs(ps.get('sizeDeletions', 0))
+        total_lines = insertions + deletions
+
+        # Categorize by size
+        for bucket_name, bucket in size_buckets.items():
+            low, high = bucket['range']
+            if low <= total_lines <= high:
+                bucket['reviews'].append(review)
+                break
+
+        # Track series vs standalone
+        topic = review.get('topic', '')
+        if topic and len(topics.get(topic, [])) > 1:
+            series_reviews.append(review)
+        else:
+            standalone_reviews.append(review)
+
+    return size_buckets, topics, standalone_reviews, series_reviews
+
+
+def calc_metrics(reviews: list) -> dict:
+    """Calculate review metrics for a set of reviews."""
+    if not reviews:
+        return {
+            'count': 0,
+            'avg_patchsets': 0,
+            'avg_hours_to_merge': 0,
+            'avg_hours_to_first_review': 0,
+        }
+
+    patchset_counts = []
+    hours_to_merge = []
+    hours_to_first_review = []
+
+    for review in reviews:
+        # Patch set count
+        ps = review.get('currentPatchSet', {})
+        ps_num = ps.get('number', 1)
+        patchset_counts.append(ps_num)
+
+        # Time to merge
+        created = review.get('createdOn', 0)
+        updated = review.get('lastUpdated', 0)
+        if created and updated:
+            hours = (updated - created) / 3600
+            hours_to_merge.append(hours)
+
+        # Time to first human review
+        first_review_ts = None
+        for comment in review.get('comments', []):
+            reviewer = comment.get('reviewer', {})
+            username = reviewer.get('username', '')
+            msg = comment.get('message', '')
+
+            # Skip bots and patch uploads
+            if username in ('zuul', 'jenkins'):
+                continue
+            if 'Uploaded patch set' in msg:
+                continue
+
+            ts = comment.get('timestamp', 0)
+            if ts and (first_review_ts is None or ts < first_review_ts):
+                first_review_ts = ts
+
+        if first_review_ts and created:
+            hours = (first_review_ts - created) / 3600
+            if hours > 0:
+                hours_to_first_review.append(hours)
+
+    return {
+        'count': len(reviews),
+        'avg_patchsets': sum(patchset_counts) / len(patchset_counts),
+        'median_patchsets': sorted(patchset_counts)[len(patchset_counts) // 2],
+        'avg_hours_to_merge': (
+            sum(hours_to_merge) / len(hours_to_merge) if hours_to_merge else 0
+        ),
+        'median_hours_to_merge': (
+            sorted(hours_to_merge)[len(hours_to_merge) // 2]
+            if hours_to_merge else 0
+        ),
+        'avg_hours_to_first_review': (
+            sum(hours_to_first_review) / len(hours_to_first_review)
+            if hours_to_first_review else 0
+        ),
+        'median_hours_to_first_review': (
+            sorted(hours_to_first_review)[len(hours_to_first_review) // 2]
+            if hours_to_first_review else 0
+        ),
+    }
+
+
+def print_results(size_buckets, topics, standalone, series):
+    """Print analysis results."""
+    print('=' * 70)
+    print('PATCH SIZE VS REVIEW METRICS')
+    print('=' * 70)
+    print(
+        f'{"Size":<10} {"Count":>6} {"Avg PS":>8} {"Med PS":>8} '
+        f'{"Med Hrs to Review":>18} {"Med Hrs to Merge":>18}'
+    )
+    print('-' * 70)
+
+    for bucket_name in ['tiny', 'small', 'medium', 'large', 'huge']:
+        bucket = size_buckets[bucket_name]
+        metrics = calc_metrics(bucket['reviews'])
+        if metrics['count'] > 0:
+            low, high = bucket['range']
+            range_str = f'{low}-{high}' if high != float('inf') else f'{low}+'
+            print(
+                f'{bucket_name:<10} {metrics["count"]:>6} '
+                f'{metrics["avg_patchsets"]:>8.1f} {metrics["median_patchsets"]:>8} '
+                f'{metrics["median_hours_to_first_review"]:>18.1f} '
+                f'{metrics["median_hours_to_merge"]:>18.1f}'
+            )
+
+    print('\n' + '=' * 70)
+    print('SERIES VS STANDALONE PATCHES')
+    print('=' * 70)
+
+    standalone_metrics = calc_metrics(standalone)
+    series_metrics = calc_metrics(series)
+
+    print(
+        f'{"Type":<15} {"Count":>6} {"Avg PS":>8} {"Med PS":>8} '
+        f'{"Med Hrs to Review":>18} {"Med Hrs to Merge":>18}'
+    )
+    print('-' * 70)
+    print(
+        f'{"Standalone":<15} {standalone_metrics["count"]:>6} '
+        f'{standalone_metrics["avg_patchsets"]:>8.1f} '
+        f'{standalone_metrics["median_patchsets"]:>8} '
+        f'{standalone_metrics["median_hours_to_first_review"]:>18.1f} '
+        f'{standalone_metrics["median_hours_to_merge"]:>18.1f}'
+    )
+    print(
+        f'{"In a series":<15} {series_metrics["count"]:>6} '
+        f'{series_metrics["avg_patchsets"]:>8.1f} '
+        f'{series_metrics["median_patchsets"]:>8} '
+        f'{series_metrics["median_hours_to_first_review"]:>18.1f} '
+        f'{series_metrics["median_hours_to_merge"]:>18.1f}'
+    )
+
+    print('\n' + '=' * 70)
+    print('SERIES LENGTH ANALYSIS')
+    print('=' * 70)
+
+    # Group series by length
+    series_by_length = defaultdict(list)
+    for topic, topic_reviews in topics.items():
+        if len(topic_reviews) > 1:
+            series_by_length[len(topic_reviews)].extend(topic_reviews)
+
+    print(
+        f'{"Series Length":>13} {"Reviews":>8} {"Avg PS":>8} '
+        f'{"Med Hrs to Review":>18} {"Med Hrs to Merge":>18}'
+    )
+    print('-' * 70)
+
+    for length in sorted(series_by_length.keys()):
+        reviews = series_by_length[length]
+        metrics = calc_metrics(reviews)
+        print(
+            f'{length:>13} {metrics["count"]:>8} '
+            f'{metrics["avg_patchsets"]:>8.1f} '
+            f'{metrics["median_hours_to_first_review"]:>18.1f} '
+            f'{metrics["median_hours_to_merge"]:>18.1f}'
+        )
+
+    # Top series examples
+    print('\n' + '=' * 70)
+    print('EXAMPLE SERIES (longest)')
+    print('=' * 70)
+
+    sorted_topics = sorted(topics.items(), key=lambda x: -len(x[1]))[:5]
+    for topic, topic_reviews in sorted_topics:
+        if len(topic_reviews) > 1:
+            print(f'\nTopic: {topic} ({len(topic_reviews)} patches)')
+            for r in topic_reviews[:3]:
+                subj = r.get('subject', '')[:50]
+                ps = r.get('currentPatchSet', {})
+                ins = ps.get('sizeInsertions', 0)
+                dels = abs(ps.get('sizeDeletions', 0))
+                print(f'  - {subj}... (+{ins}/-{dels})')
+            if len(topic_reviews) > 3:
+                print(f'  ... and {len(topic_reviews) - 3} more')
+
+    print('\n' + '=' * 70)
+    print('RECOMMENDATIONS')
+    print('=' * 70)
+
+    # Compare metrics
+    if standalone_metrics['count'] > 0 and series_metrics['count'] > 0:
+        review_diff = (
+            series_metrics['median_hours_to_first_review'] -
+            standalone_metrics['median_hours_to_first_review']
+        )
+        merge_diff = (
+            series_metrics['median_hours_to_merge'] -
+            standalone_metrics['median_hours_to_merge']
+        )
+        ps_diff = (
+            series_metrics['avg_patchsets'] -
+            standalone_metrics['avg_patchsets']
+        )
+
+        if review_diff > 0:
+            print(
+                f'Series patches take {review_diff:.1f} hours LONGER '
+                'to get first review'
+            )
+        else:
+            print(
+                f'Series patches get first review {-review_diff:.1f} hours '
+                'FASTER'
+            )
+
+        if merge_diff > 0:
+            print(
+                f'Series patches take {merge_diff:.1f} hours LONGER to merge'
+            )
+        else:
+            print(f'Series patches merge {-merge_diff:.1f} hours FASTER')
+
+        if ps_diff > 0:
+            print(
+                f'Series patches need {ps_diff:.1f} MORE patch set revisions '
+                'on average'
+            )
+        else:
+            print(
+                f'Series patches need {-ps_diff:.1f} FEWER patch set revisions'
+            )
+
+    # Size recommendations
+    print('\nBy patch size:')
+    tiny_m = calc_metrics(size_buckets['tiny']['reviews'])
+    large_m = calc_metrics(size_buckets['large']['reviews'])
+    if tiny_m['count'] > 0 and large_m['count'] > 0:
+        if tiny_m['median_patchsets'] < large_m['median_patchsets']:
+            print(
+                f'  Tiny patches need {tiny_m["median_patchsets"]:.0f} '
+                f'revisions vs {large_m["median_patchsets"]:.0f} for large'
+            )
+        review_ratio = (
+            large_m['median_hours_to_first_review'] /
+            tiny_m['median_hours_to_first_review']
+        ) if tiny_m['median_hours_to_first_review'] > 0 else 0
+        if review_ratio > 1:
+            print(
+                f'  Large patches take {review_ratio:.1f}x longer to get '
+                'first review'
+            )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Analyze patch size and series length vs review response',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        '--limit', '-n',
+        type=int,
+        default=100,
+        help='Number of reviews to fetch per project (default: 100)',
+    )
+    parser.add_argument(
+        '--project', '-p',
+        action='append',
+        dest='projects',
+        help='Project to analyze (can specify multiple). '
+             'Default: openstack/kolla and openstack/kolla-ansible',
+    )
+
+    args = parser.parse_args()
+
+    projects = args.projects or ['openstack/kolla', 'openstack/kolla-ansible']
+
+    print(f'Fetching reviews from: {", ".join(projects)}')
+    print(f'Limit per project: {args.limit}\n')
+
+    all_reviews = []
+    for project in projects:
+        print(f'Fetching {project}...', end=' ', flush=True)
+        reviews = fetch_reviews(project, args.limit)
+        print(f'{len(reviews)} reviews')
+        all_reviews.extend(reviews)
+
+    if not all_reviews:
+        print('No reviews found.')
+        sys.exit(1)
+
+    print(f'\nAnalyzing {len(all_reviews)} total reviews...\n')
+
+    size_buckets, topics, standalone, series = analyze_reviews(all_reviews)
+    print_results(size_buckets, topics, standalone, series)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/analyze-gerrit-review-times
+++ b/tools/analyze-gerrit-review-times
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""
+Analyze Gerrit review timestamps to find patterns.
+
+This script fetches recent reviews from Kolla and Kolla-Ansible and analyzes
+when human reviewers are most active. Use this to determine optimal times
+to post changes for faster reviews.
+
+Usage:
+    analyze-gerrit-review-times              # Analyze last 100 reviews
+    analyze-gerrit-review-times --limit 200  # Analyze last 200 reviews
+    analyze-gerrit-review-times --project openstack/nova  # Different project
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+
+
+def fetch_reviews(project: str, limit: int) -> list:
+    """Fetch reviews from Gerrit via SSH API."""
+    cmd = [
+        'ssh', '-p', '29418', 'review.opendev.org',
+        'gerrit', 'query',
+        '--format=JSON',
+        '--comments',
+        '--all-approvals',
+        f'project:{project} status:merged limit:{limit}'
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f'Error fetching from {project}: {result.stderr}', file=sys.stderr)
+        return []
+
+    reviews = []
+    for line in result.stdout.strip().split('\n'):
+        if line:
+            data = json.loads(line)
+            if data.get('type') != 'stats':
+                reviews.append(data)
+    return reviews
+
+
+def analyze_reviews(reviews: list):
+    """Analyze review timestamps for patterns."""
+    # Track human review activities (exclude Zuul bot)
+    review_hours_utc = defaultdict(int)
+    review_days = defaultdict(int)
+    reviewer_hours = defaultdict(lambda: defaultdict(int))
+    reviewer_activity = defaultdict(int)
+    time_to_first_review = []
+
+    for review in reviews:
+        created_ts = review.get('createdOn', 0)
+        first_human_review_ts = None
+
+        for comment in review.get('comments', []):
+            reviewer = comment.get('reviewer', {})
+            username = reviewer.get('username', '')
+            name = reviewer.get('name', '')
+
+            # Skip bots
+            if username in ('zuul', 'jenkins') or 'bot' in username.lower():
+                continue
+
+            # Skip "Uploaded patch set" messages from the author
+            msg = comment.get('message', '')
+            if 'Uploaded patch set' in msg:
+                continue
+
+            ts = comment.get('timestamp', 0)
+            if ts == 0:
+                continue
+
+            dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+
+            # Track activity
+            review_hours_utc[dt.hour] += 1
+            review_days[dt.strftime('%A')] += 1
+            reviewer_hours[name or username][dt.hour] += 1
+            reviewer_activity[name or username] += 1
+
+            # Track time to first human review
+            if first_human_review_ts is None or ts < first_human_review_ts:
+                first_human_review_ts = ts
+
+        if first_human_review_ts and created_ts:
+            hours_to_review = (first_human_review_ts - created_ts) / 3600
+            if hours_to_review > 0:  # Exclude immediate self-comments
+                time_to_first_review.append(hours_to_review)
+
+    return {
+        'hours_utc': dict(review_hours_utc),
+        'days': dict(review_days),
+        'reviewer_hours': {k: dict(v) for k, v in reviewer_hours.items()},
+        'reviewer_activity': dict(reviewer_activity),
+        'time_to_first_review': time_to_first_review,
+    }
+
+
+def print_results(data: dict):
+    """Print analysis results."""
+    review_hours_utc = data['hours_utc']
+    review_days = data['days']
+    reviewer_hours = data['reviewer_hours']
+    reviewer_activity = data['reviewer_activity']
+    time_to_first_review = data['time_to_first_review']
+
+    print('=' * 60)
+    print('REVIEW ACTIVITY BY HOUR (UTC)')
+    print('=' * 60)
+    max_count = max(review_hours_utc.values()) if review_hours_utc else 1
+    for hour in range(24):
+        count = review_hours_utc.get(hour, 0)
+        bar = '#' * int(40 * count / max_count) if max_count else ''
+        print(f'{hour:02d}:00 UTC | {bar} ({count})')
+
+    print('\n' + '=' * 60)
+    print('REVIEW ACTIVITY BY DAY OF WEEK')
+    print('=' * 60)
+    day_order = [
+        'Monday', 'Tuesday', 'Wednesday', 'Thursday',
+        'Friday', 'Saturday', 'Sunday'
+    ]
+    max_day = max(review_days.values()) if review_days else 1
+    for day in day_order:
+        count = review_days.get(day, 0)
+        bar = '#' * int(40 * count / max_day) if max_day else ''
+        print(f'{day:9} | {bar} ({count})')
+
+    print('\n' + '=' * 60)
+    print('TOP REVIEWERS AND THEIR PEAK HOURS')
+    print('=' * 60)
+    top_reviewers = sorted(reviewer_activity.items(), key=lambda x: -x[1])[:10]
+    for name, total in top_reviewers:
+        hours = reviewer_hours.get(name, {})
+        if hours:
+            peak_hour = max(hours, key=hours.get)
+            # Find timezone guess based on peak hour
+            # Assuming peak is morning/workday: 9 AM local
+            tz_offset = (peak_hour - 9) % 24
+            if tz_offset > 12:
+                tz_offset -= 24
+            tz_str = f'UTC{tz_offset:+d}' if tz_offset != 0 else 'UTC'
+            print(
+                f'{name[:30]:30} | {total:3} reviews | '
+                f'peak {peak_hour:02d}:00 UTC (~{tz_str})'
+            )
+
+    print('\n' + '=' * 60)
+    print('TIME TO FIRST HUMAN REVIEW')
+    print('=' * 60)
+    if time_to_first_review:
+        time_to_first_review.sort()
+        n = len(time_to_first_review)
+        median = time_to_first_review[n // 2]
+        avg = sum(time_to_first_review) / n
+        p25 = time_to_first_review[n // 4]
+        p75 = time_to_first_review[3 * n // 4]
+        print(f'Median: {median:.1f} hours')
+        print(f'Average: {avg:.1f} hours')
+        print(f'25th percentile: {p25:.1f} hours')
+        print(f'75th percentile: {p75:.1f} hours')
+        print(f'Min: {min(time_to_first_review):.1f} hours')
+        print(f'Max: {max(time_to_first_review):.1f} hours')
+
+    print('\n' + '=' * 60)
+    print('RECOMMENDATIONS')
+    print('=' * 60)
+
+    # Find best hours
+    best_hours = sorted(review_hours_utc.items(), key=lambda x: -x[1])[:5]
+    print(
+        f'Most active review hours (UTC): '
+        f'{", ".join(f"{h:02d}:00" for h, _ in best_hours)}'
+    )
+
+    # Find best days
+    best_days = sorted(
+        [(d, review_days.get(d, 0)) for d in day_order],
+        key=lambda x: -x[1]
+    )[:3]
+    print(f'Most active review days: {", ".join(d for d, _ in best_days)}')
+
+    # Convert to common timezones
+    print('\nOptimal posting times by timezone:')
+    peak_utc = best_hours[0][0] if best_hours else 12
+    timezones = [
+        ('US Pacific', -8),
+        ('US Eastern', -5),
+        ('Europe/Berlin', 1),
+        ('Australia/Sydney', 11),
+    ]
+    for tz_name, offset in timezones:
+        local_hour = (peak_utc + offset) % 24
+        print(f'  {tz_name}: Post by {local_hour:02d}:00 local time')
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Analyze Gerrit review timing patterns',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        '--limit', '-n',
+        type=int,
+        default=100,
+        help='Number of reviews to fetch per project (default: 100)',
+    )
+    parser.add_argument(
+        '--project', '-p',
+        action='append',
+        dest='projects',
+        help='Project to analyze (can specify multiple). '
+             'Default: openstack/kolla and openstack/kolla-ansible',
+    )
+
+    args = parser.parse_args()
+
+    projects = args.projects or ['openstack/kolla', 'openstack/kolla-ansible']
+
+    print(f'Fetching reviews from: {", ".join(projects)}')
+    print(f'Limit per project: {args.limit}\n')
+
+    all_reviews = []
+    for project in projects:
+        print(f'Fetching {project}...', end=' ', flush=True)
+        reviews = fetch_reviews(project, args.limit)
+        print(f'{len(reviews)} reviews')
+        all_reviews.extend(reviews)
+
+    if not all_reviews:
+        print('No reviews found.')
+        sys.exit(1)
+
+    print(f'\nAnalyzing {len(all_reviews)} total reviews...\n')
+
+    data = analyze_reviews(all_reviews)
+    print_results(data)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/gerrit-pre-push-lint
+++ b/tools/gerrit-pre-push-lint
@@ -1,0 +1,887 @@
+#!/usr/bin/env python3
+"""
+Pre-push linter for OpenStack Gerrit submissions.
+
+This tool checks common issues that reviewers typically flag during code review
+of Kolla and Kolla-Ansible patches. Run this before pushing to Gerrit to catch
+issues early.
+
+Based on analysis of actual Gerrit review comments from openstack/kolla and
+openstack/kolla-ansible projects.
+
+Usage:
+    cd /path/to/openstack-project
+    gerrit-pre-push-lint              # Check staged changes
+    gerrit-pre-push-lint --all        # Check all uncommitted changes
+    gerrit-pre-push-lint --commit     # Check the most recent commit
+    gerrit-pre-push-lint --stack 5    # Check the last 5 commits (stacked patches)
+    gerrit-pre-push-lint --range origin/master..HEAD  # Check commits in range
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+
+class Severity(Enum):
+    ERROR = 'error'
+    WARNING = 'warning'
+    INFO = 'info'
+
+
+@dataclass
+class Issue:
+    severity: Severity
+    file: str
+    line: Optional[int]
+    message: str
+    suggestion: Optional[str] = None
+
+
+class GerritLinter:
+    """Linter for OpenStack Gerrit submissions."""
+
+    # Commands that are typically read-only and should use changed_when: false
+    READ_ONLY_COMMANDS = [
+        'losetup -f',
+        'losetup --find',
+        'cat ',
+        'grep ',
+        'find ',
+        'ls ',
+        'stat ',
+        'head ',
+        'tail ',
+        'wc ',
+        'id ',
+        'whoami',
+        'hostname',
+        'uname ',
+        'getent ',
+        'which ',
+        'type ',
+        'command -v',
+    ]
+
+    # Bug reference patterns in commit messages
+    BUG_PATTERNS = [
+        r'Closes-Bug:\s*#?\d+',
+        r'Partial-Bug:\s*#?\d+',
+        r'Related-Bug:\s*#?\d+',
+        r'Fixes:\s*https?://bugs\.launchpad\.net/',
+        r'https?://bugs\.launchpad\.net/[^\s]+',
+        r'https?://storyboard\.openstack\.org/',
+    ]
+
+    def __init__(self, repo_path: str = '.'):
+        self.repo_path = Path(repo_path).resolve()
+        self.issues: list[Issue] = []
+        self.project_name = self._detect_project()
+
+    def _detect_project(self) -> str:
+        """Detect the OpenStack project name from git remote."""
+        try:
+            result = subprocess.run(
+                ['git', 'remote', 'get-url', 'origin'],
+                capture_output=True,
+                text=True,
+                cwd=self.repo_path,
+            )
+            if result.returncode == 0:
+                url = result.stdout.strip()
+                # Extract project name from URL like
+                # https://opendev.org/openstack/kolla.git
+                if 'openstack/' in url:
+                    match = re.search(r'openstack/([^/\s.]+)', url)
+                    if match:
+                        return match.group(1)
+        except Exception:
+            pass
+        return 'unknown'
+
+    def add_issue(
+        self,
+        severity: Severity,
+        file: str,
+        line: Optional[int],
+        message: str,
+        suggestion: Optional[str] = None,
+    ):
+        """Add an issue to the list."""
+        self.issues.append(Issue(severity, file, line, message, suggestion))
+
+    def get_changed_files(self, mode: str = 'staged') -> list[str]:
+        """Get list of changed files based on mode."""
+        if mode == 'staged':
+            cmd = ['git', 'diff', '--cached', '--name-only']
+        elif mode == 'all':
+            cmd = ['git', 'diff', '--name-only', 'HEAD']
+        elif mode == 'commit':
+            cmd = ['git', 'diff', '--name-only', 'HEAD~1', 'HEAD']
+        else:
+            raise ValueError(f'Unknown mode: {mode}')
+
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, cwd=self.repo_path
+        )
+        if result.returncode != 0:
+            return []
+        return [f for f in result.stdout.strip().split('\n') if f]
+
+    def get_file_diff(self, filepath: str, mode: str = 'staged') -> str:
+        """Get the diff for a specific file."""
+        if mode == 'staged':
+            cmd = ['git', 'diff', '--cached', '--', filepath]
+        elif mode == 'all':
+            cmd = ['git', 'diff', 'HEAD', '--', filepath]
+        elif mode == 'commit':
+            cmd = ['git', 'diff', 'HEAD~1', 'HEAD', '--', filepath]
+        else:
+            raise ValueError(f'Unknown mode: {mode}')
+
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, cwd=self.repo_path
+        )
+        return result.stdout if result.returncode == 0 else ''
+
+    def get_commit_message(self, mode: str = 'staged') -> str:
+        """Get the commit message."""
+        if mode == 'commit':
+            result = subprocess.run(
+                ['git', 'log', '-1', '--format=%B'],
+                capture_output=True,
+                text=True,
+                cwd=self.repo_path,
+            )
+            return result.stdout if result.returncode == 0 else ''
+        # For staged changes, we can't get the message yet
+        return ''
+
+    def read_file(self, filepath: str) -> Optional[str]:
+        """Read a file from the working directory."""
+        full_path = self.repo_path / filepath
+        try:
+            return full_path.read_text()
+        except Exception:
+            return None
+
+    def get_commits_in_range(self, range_spec: str) -> list[tuple[str, str]]:
+        """Get list of commits in a range. Returns [(sha, subject), ...]."""
+        result = subprocess.run(
+            ['git', 'log', '--format=%H %s', '--reverse', range_spec],
+            capture_output=True,
+            text=True,
+            cwd=self.repo_path,
+        )
+        if result.returncode != 0:
+            return []
+        commits = []
+        for line in result.stdout.strip().split('\n'):
+            if line:
+                parts = line.split(' ', 1)
+                sha = parts[0]
+                subject = parts[1] if len(parts) > 1 else ''
+                commits.append((sha, subject))
+        return commits
+
+    def get_changed_files_for_commit(self, commit: str) -> list[str]:
+        """Get list of changed files for a specific commit."""
+        result = subprocess.run(
+            ['git', 'diff', '--name-only', f'{commit}~1', commit],
+            capture_output=True,
+            text=True,
+            cwd=self.repo_path,
+        )
+        if result.returncode != 0:
+            # Maybe first commit, try without parent
+            result = subprocess.run(
+                ['git', 'diff-tree', '--no-commit-id', '--name-only', '-r', commit],
+                capture_output=True,
+                text=True,
+                cwd=self.repo_path,
+            )
+        if result.returncode != 0:
+            return []
+        return [f for f in result.stdout.strip().split('\n') if f]
+
+    def get_commit_message_for_sha(self, commit: str) -> str:
+        """Get the commit message for a specific commit SHA."""
+        result = subprocess.run(
+            ['git', 'log', '-1', '--format=%B', commit],
+            capture_output=True,
+            text=True,
+            cwd=self.repo_path,
+        )
+        return result.stdout if result.returncode == 0 else ''
+
+    def read_file_at_commit(self, filepath: str, commit: str) -> Optional[str]:
+        """Read a file at a specific commit."""
+        result = subprocess.run(
+            ['git', 'show', f'{commit}:{filepath}'],
+            capture_output=True,
+            text=True,
+            cwd=self.repo_path,
+        )
+        if result.returncode == 0:
+            return result.stdout
+        return None
+
+    # =========================================================================
+    # Check 1: Release Notes
+    # =========================================================================
+    def check_release_notes(self, changed_files: list[str]):
+        """Check if changes warrant a release note."""
+        # File patterns that typically need release notes
+        code_patterns = [
+            r'\.py$',
+            r'\.j2$',
+            r'\.yml$',
+            r'\.yaml$',
+            r'Dockerfile',
+        ]
+
+        # File patterns that are documentation/config only
+        exempt_patterns = [
+            r'^doc/',
+            r'^\.github/',
+            r'^tox\.ini$',
+            r'^setup\.cfg$',
+            r'^requirements.*\.txt$',
+            r'^test-requirements.*\.txt$',
+            r'^releasenotes/',
+            r'^\.pre-commit',
+        ]
+
+        has_code_changes = False
+        has_release_note = False
+
+        for f in changed_files:
+            # Check for release note
+            if f.startswith('releasenotes/notes/'):
+                has_release_note = True
+
+            # Check if exempt
+            exempt = any(re.search(p, f) for p in exempt_patterns)
+            if exempt:
+                continue
+
+            # Check if code change
+            if any(re.search(p, f) for p in code_patterns):
+                has_code_changes = True
+
+        if has_code_changes and not has_release_note:
+            self.add_issue(
+                Severity.WARNING,
+                'COMMIT',
+                None,
+                'Code changes detected but no release note found.',
+                'Consider adding a release note using: '
+                'reno new <slug> --edit\n'
+                '  Release notes should describe the change from a '
+                "user's perspective.",
+            )
+
+    # =========================================================================
+    # Check 2: Bug References
+    # =========================================================================
+    def check_bug_reference(self, commit_message: str, changed_files: list[str]):
+        """Check for bug references on significant changes."""
+        if not commit_message:
+            return
+
+        # Check if there's a bug reference
+        has_bug_ref = any(
+            re.search(p, commit_message, re.IGNORECASE)
+            for p in self.BUG_PATTERNS
+        )
+
+        if has_bug_ref:
+            return
+
+        # Determine if this is a significant change
+        exempt_prefixes = ['doc:', 'docs:', 'trivial:', 'typo:']
+        first_line = commit_message.split('\n')[0].lower()
+        is_trivial = any(first_line.startswith(p) for p in exempt_prefixes)
+
+        if is_trivial:
+            return
+
+        # Count non-trivial file changes
+        significant_files = 0
+        for f in changed_files:
+            if not re.match(r'^(doc/|\.github/|test)', f):
+                significant_files += 1
+
+        if significant_files >= 3:
+            self.add_issue(
+                Severity.INFO,
+                'COMMIT',
+                None,
+                'Significant changes without bug reference.',
+                'Consider filing a bug at '
+                'https://bugs.launchpad.net/kolla or '
+                'https://bugs.launchpad.net/kolla-ansible\n'
+                '  Add to commit message: Closes-Bug: #NNNNNN',
+            )
+
+    # =========================================================================
+    # Check 3: Commit Message Quality
+    # =========================================================================
+    def check_commit_message(self, commit_message: str):
+        """Check commit message formatting and content."""
+        if not commit_message:
+            return
+
+        lines = commit_message.split('\n')
+        if not lines:
+            return
+
+        subject = lines[0]
+
+        # Check subject line length
+        if len(subject) > 72:
+            self.add_issue(
+                Severity.WARNING,
+                'COMMIT',
+                1,
+                f'Subject line too long ({len(subject)} chars, max 72).',
+                'Keep the subject line concise. Move details to the body.',
+            )
+        elif len(subject) > 50:
+            self.add_issue(
+                Severity.INFO,
+                'COMMIT',
+                1,
+                f'Subject line could be shorter ({len(subject)} chars, '
+                'ideal ≤50).',
+                None,
+            )
+
+        # Check for Trivial: misuse
+        if subject.lower().startswith('trivial:'):
+            # Count changed files and lines
+            self.add_issue(
+                Severity.WARNING,
+                'COMMIT',
+                1,
+                '"Trivial:" prefix may not be appropriate.',
+                'Only use "Trivial:" for truly trivial changes '
+                '(typos, whitespace).\n'
+                '  If this is a fix or feature, remove the prefix.',
+            )
+
+        # Check for Change-Id
+        if 'Change-Id:' not in commit_message:
+            self.add_issue(
+                Severity.INFO,
+                'COMMIT',
+                None,
+                'No Change-Id found.',
+                'The Gerrit commit-msg hook will add this automatically.\n'
+                '  Install hook: scp -p -P 29418 '
+                'review.opendev.org:hooks/commit-msg .git/hooks/',
+            )
+
+        # Check Depends-On usage
+        depends_on_match = re.search(
+            r'Depends-On:\s*https://review\.opendev\.org/c/openstack/([^/]+)',
+            commit_message,
+        )
+        if depends_on_match:
+            dep_project = depends_on_match.group(1)
+            if dep_project == self.project_name:
+                self.add_issue(
+                    Severity.WARNING,
+                    'COMMIT',
+                    None,
+                    f'Depends-On references the same project ({dep_project}).',
+                    'For dependencies within the same repository, '
+                    'rebase your changes instead.\n'
+                    '  Stack commits by rebasing: git rebase -i HEAD~N',
+                )
+
+    # =========================================================================
+    # Check 4: YAML Line Length
+    # =========================================================================
+    def check_yaml_line_length(self, filepath: str, content: str):
+        """Check YAML files for line length violations."""
+        if not filepath.endswith(('.yml', '.yaml')):
+            return
+
+        max_length = 160  # yamllint default
+        lines = content.split('\n')
+
+        for i, line in enumerate(lines, 1):
+            if len(line) > max_length:
+                self.add_issue(
+                    Severity.WARNING,
+                    filepath,
+                    i,
+                    f'Line exceeds {max_length} characters ({len(line)} chars).',
+                    'Consider breaking the line or using YAML '
+                    'multi-line syntax.',
+                )
+
+    # =========================================================================
+    # Check 5: Ansible changed_when
+    # =========================================================================
+    def check_changed_when(self, filepath: str, content: str):
+        """Check for incorrect changed_when usage in Ansible tasks."""
+        if not filepath.endswith(('.yml', '.yaml')):
+            return
+
+        # Look for tasks with command/shell and changed_when: true
+        # that are actually read-only
+        lines = content.split('\n')
+        in_task = False
+        task_start = 0
+        task_lines = []
+        task_name = ''
+
+        for i, line in enumerate(lines, 1):
+            # Detect task start
+            if re.match(r'\s*-\s+name:', line):
+                if in_task and task_lines:
+                    self._analyze_task(
+                        filepath, task_start, task_name, task_lines
+                    )
+                in_task = True
+                task_start = i
+                task_lines = [line]
+                match = re.search(r'name:\s*(.+)', line)
+                task_name = match.group(1) if match else 'unnamed'
+            elif in_task:
+                if line.strip() and not line.startswith(' ') and not line.startswith('\t'):
+                    # End of task block
+                    self._analyze_task(
+                        filepath, task_start, task_name, task_lines
+                    )
+                    in_task = False
+                    task_lines = []
+                else:
+                    task_lines.append(line)
+
+        # Handle last task
+        if in_task and task_lines:
+            self._analyze_task(filepath, task_start, task_name, task_lines)
+
+    def _analyze_task(
+        self, filepath: str, line_num: int, name: str, task_lines: list[str]
+    ):
+        """Analyze a single Ansible task for issues."""
+        task_content = '\n'.join(task_lines)
+
+        # Check for changed_when: true with read-only commands
+        if 'changed_when: true' in task_content or "changed_when: 'true'" in task_content:
+            # Look for command or shell
+            cmd_match = re.search(
+                r'(command|shell):\s*(.+)', task_content, re.MULTILINE
+            )
+            if cmd_match:
+                cmd = cmd_match.group(2).strip()
+                for read_only in self.READ_ONLY_COMMANDS:
+                    if read_only in cmd:
+                        self.add_issue(
+                            Severity.WARNING,
+                            filepath,
+                            line_num,
+                            f'Task "{name}" uses changed_when: true '
+                            'with a read-only command.',
+                            f'The command "{cmd[:50]}..." appears to be '
+                            'read-only.\n'
+                            '  Use changed_when: false instead.',
+                        )
+                        break
+
+    # =========================================================================
+    # Check 6: Jinja2 Template Issues
+    # =========================================================================
+    def check_jinja2_issues(self, filepath: str, content: str):
+        """Check for common Jinja2 template issues."""
+        if not filepath.endswith(('.yml', '.yaml', '.j2')):
+            return
+
+        lines = content.split('\n')
+
+        for i, line in enumerate(lines, 1):
+            # Check for {{} typo (missing space or extra brace)
+            if '{{} ' in line or '{{}' in line:
+                self.add_issue(
+                    Severity.ERROR,
+                    filepath,
+                    i,
+                    'Jinja2 syntax error: "{{}" found.',
+                    'Did you mean "{{ "? Check for typos in Jinja2 variables.',
+                )
+
+            # Check for missing space after {{
+            matches = re.findall(r'\{\{[^\s{]', line)
+            for match in matches:
+                if match != '{{-':  # {{- is valid for whitespace control
+                    self.add_issue(
+                        Severity.INFO,
+                        filepath,
+                        i,
+                        'Missing space after "{{" in Jinja2 expression.',
+                        'Add a space: "{{ variable }}" not "{{variable}}"',
+                    )
+                    break
+
+            # Check for missing space before }}
+            matches = re.findall(r'[^\s}]\}\}', line)
+            for match in matches:
+                if match[-3:] != '-}}':  # -}} is valid for whitespace control
+                    self.add_issue(
+                        Severity.INFO,
+                        filepath,
+                        i,
+                        'Missing space before "}}" in Jinja2 expression.',
+                        'Add a space: "{{ variable }}" not "{{variable}}"',
+                    )
+                    break
+
+    # =========================================================================
+    # Check 7: TODO Comments
+    # =========================================================================
+    def check_todo_comments(self, filepath: str, content: str):
+        """Check that TODO comments have release targets."""
+        lines = content.split('\n')
+
+        for i, line in enumerate(lines, 1):
+            # Look for TODO comments
+            if re.search(r'\bTODO\b', line, re.IGNORECASE):
+                # Check if it has a release target
+                has_release = re.search(
+                    r'(202[4-9]\.[12]|[A-Z]/202[4-9]|'
+                    r'master|epoxy|flamingo|gazpacho|dalmatian|caracal)',
+                    line,
+                    re.IGNORECASE,
+                )
+                if not has_release:
+                    self.add_issue(
+                        Severity.INFO,
+                        filepath,
+                        i,
+                        'TODO comment without release target.',
+                        'Add a release target: '
+                        'TODO(username): Remove in G/2026.1 release',
+                    )
+
+    # =========================================================================
+    # Check 8: File Mode Issues
+    # =========================================================================
+    def check_file_modes(self, filepath: str, content: str):
+        """Check for incorrect file mode settings in Ansible."""
+        if not filepath.endswith(('.yml', '.yaml')):
+            return
+
+        lines = content.split('\n')
+        in_file_or_copy = False
+        task_creates_dir = False
+
+        for i, line in enumerate(lines, 1):
+            # Track if we're in a file/copy/template task
+            if re.search(r'(file|copy|template):', line):
+                in_file_or_copy = True
+                task_creates_dir = False
+            elif in_file_or_copy:
+                if 'state: directory' in line:
+                    task_creates_dir = True
+                # Check for 0644 mode on directories
+                if task_creates_dir and re.search(r'mode:\s*["\']?0644', line):
+                    self.add_issue(
+                        Severity.WARNING,
+                        filepath,
+                        i,
+                        'Directory created with mode 0644.',
+                        'Directories typically need 0755 for traversal. '
+                        'Use mode: "0755" for directories.',
+                    )
+                # Reset on new task
+                if re.match(r'\s*-\s+', line):
+                    in_file_or_copy = False
+
+    # =========================================================================
+    # Main Run Method
+    # =========================================================================
+    def run(self, mode: str = 'staged') -> int:
+        """Run all checks and return exit code."""
+        changed_files = self.get_changed_files(mode)
+
+        if not changed_files:
+            print('No changes detected.')
+            return 0
+
+        print(f'Checking {len(changed_files)} changed files...\n')
+
+        # Get commit message for commit mode
+        commit_message = self.get_commit_message(mode)
+
+        # Run global checks
+        self.check_release_notes(changed_files)
+        if commit_message:
+            self.check_bug_reference(commit_message, changed_files)
+            self.check_commit_message(commit_message)
+
+        # Run per-file checks
+        for filepath in changed_files:
+            content = self.read_file(filepath)
+            if content is None:
+                continue
+
+            self.check_yaml_line_length(filepath, content)
+            self.check_changed_when(filepath, content)
+            self.check_jinja2_issues(filepath, content)
+            self.check_todo_comments(filepath, content)
+            self.check_file_modes(filepath, content)
+
+        # Report issues
+        return self._report_issues()
+
+    def run_stack(self, range_spec: str) -> int:
+        """Run checks on a stack of commits and return exit code."""
+        commits = self.get_commits_in_range(range_spec)
+
+        if not commits:
+            print(f'No commits found in range: {range_spec}')
+            return 0
+
+        print(f'Checking {len(commits)} stacked commits...\n')
+        print('=' * 60)
+
+        total_errors = 0
+        total_warnings = 0
+        total_infos = 0
+        commit_results = []
+
+        for i, (sha, subject) in enumerate(commits, 1):
+            # Reset issues for each commit
+            self.issues = []
+
+            print(f'\n[{i}/{len(commits)}] {sha[:8]} {subject[:50]}')
+            print('-' * 60)
+
+            changed_files = self.get_changed_files_for_commit(sha)
+            if not changed_files:
+                print('  No changed files.')
+                commit_results.append((sha, subject, 0, 0, 0))
+                continue
+
+            print(f'  {len(changed_files)} changed files')
+
+            # Get commit message
+            commit_message = self.get_commit_message_for_sha(sha)
+
+            # Run global checks
+            self.check_release_notes(changed_files)
+            if commit_message:
+                self.check_bug_reference(commit_message, changed_files)
+                self.check_commit_message(commit_message)
+
+            # Run per-file checks
+            for filepath in changed_files:
+                content = self.read_file_at_commit(filepath, sha)
+                if content is None:
+                    continue
+
+                self.check_yaml_line_length(filepath, content)
+                self.check_changed_when(filepath, content)
+                self.check_jinja2_issues(filepath, content)
+                self.check_todo_comments(filepath, content)
+                self.check_file_modes(filepath, content)
+
+            # Count issues for this commit
+            errors = len(
+                [x for x in self.issues if x.severity == Severity.ERROR]
+            )
+            warnings = len(
+                [x for x in self.issues if x.severity == Severity.WARNING]
+            )
+            infos = len(
+                [x for x in self.issues if x.severity == Severity.INFO]
+            )
+
+            total_errors += errors
+            total_warnings += warnings
+            total_infos += infos
+            commit_results.append((sha, subject, errors, warnings, infos))
+
+            # Print issues for this commit
+            if self.issues:
+                for issue in self.issues:
+                    self._print_issue(issue)
+            else:
+                print('  ✓ No issues')
+
+        # Print summary
+        print('\n' + '=' * 60)
+        print('STACK SUMMARY')
+        print('=' * 60)
+
+        for sha, subject, errors, warnings, infos in commit_results:
+            if errors > 0:
+                status = '✗'
+            elif warnings > 0:
+                status = '⚠'
+            else:
+                status = '✓'
+            issues_str = []
+            if errors:
+                issues_str.append(f'{errors}E')
+            if warnings:
+                issues_str.append(f'{warnings}W')
+            if infos:
+                issues_str.append(f'{infos}I')
+            issues_display = ' '.join(issues_str) if issues_str else 'clean'
+            print(f'  {status} {sha[:8]} [{issues_display:>10}] {subject[:40]}')
+
+        print('\n' + '-' * 60)
+        print(
+            f'Total: {total_errors} errors, {total_warnings} warnings, '
+            f'{total_infos} info across {len(commits)} commits'
+        )
+
+        if total_errors:
+            print('\n✗ Fix errors before pushing.')
+            return 1
+        elif total_warnings:
+            print('\n⚠ Consider addressing warnings before pushing.')
+            return 0
+        else:
+            print('\n✓ Stack looks good!')
+            return 0
+
+    def _report_issues(self) -> int:
+        """Report all issues found and return exit code."""
+        if not self.issues:
+            print('✓ No issues found!')
+            return 0
+
+        # Group by severity
+        errors = [i for i in self.issues if i.severity == Severity.ERROR]
+        warnings = [i for i in self.issues if i.severity == Severity.WARNING]
+        infos = [i for i in self.issues if i.severity == Severity.INFO]
+
+        # Print issues
+        for issue in self.issues:
+            self._print_issue(issue)
+
+        # Summary
+        print('\n' + '=' * 60)
+        print(
+            f'Summary: {len(errors)} errors, {len(warnings)} warnings, '
+            f'{len(infos)} info'
+        )
+
+        if errors:
+            print('\n✗ Fix errors before pushing.')
+            return 1
+        elif warnings:
+            print('\n⚠ Consider addressing warnings before pushing.')
+            return 0
+        else:
+            print('\n✓ Only informational messages. Ready to push.')
+            return 0
+
+    def _print_issue(self, issue: Issue):
+        """Print a single issue."""
+        # Color codes
+        colors = {
+            Severity.ERROR: '\033[91m',  # Red
+            Severity.WARNING: '\033[93m',  # Yellow
+            Severity.INFO: '\033[94m',  # Blue
+        }
+        reset = '\033[0m'
+
+        color = colors.get(issue.severity, '')
+        severity_str = issue.severity.value.upper()
+
+        location = issue.file
+        if issue.line:
+            location += f':{issue.line}'
+
+        print(f'{color}[{severity_str}]{reset} {location}')
+        print(f'  {issue.message}')
+        if issue.suggestion:
+            for line in issue.suggestion.split('\n'):
+                print(f'  → {line}')
+        print()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Pre-push linter for OpenStack Gerrit submissions',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        '--staged',
+        action='store_true',
+        default=True,
+        help='Check staged changes (default)',
+    )
+    parser.add_argument(
+        '--all',
+        action='store_true',
+        help='Check all uncommitted changes',
+    )
+    parser.add_argument(
+        '--commit',
+        action='store_true',
+        help='Check the most recent commit',
+    )
+    parser.add_argument(
+        '--stack',
+        '-s',
+        type=int,
+        metavar='N',
+        help='Check the last N commits (stacked patches)',
+    )
+    parser.add_argument(
+        '--range',
+        metavar='REF',
+        help='Check commits in range (e.g., origin/master..HEAD)',
+    )
+    parser.add_argument(
+        '--repo',
+        '-r',
+        default='.',
+        help='Path to git repository (default: current directory)',
+    )
+
+    args = parser.parse_args()
+
+    # Verify we're in a git repo
+    if not (Path(args.repo) / '.git').exists():
+        print(f'Error: {args.repo} is not a git repository')
+        sys.exit(1)
+
+    linter = GerritLinter(args.repo)
+    print(f'Project: {linter.project_name}')
+
+    # Determine mode and run
+    if args.stack:
+        print(f'Mode: stack (last {args.stack} commits)\n')
+        sys.exit(linter.run_stack(f'HEAD~{args.stack}..HEAD'))
+    elif args.range:
+        print(f'Mode: range ({args.range})\n')
+        sys.exit(linter.run_stack(args.range))
+    elif args.commit:
+        print('Mode: commit\n')
+        sys.exit(linter.run('commit'))
+    elif args.all:
+        print('Mode: all\n')
+        sys.exit(linter.run('all'))
+    else:
+        print('Mode: staged\n')
+        sys.exit(linter.run('staged'))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This commit adds tools for analyzing OpenStack Gerrit reviews and a linter for catching common issues before pushing patches:

New tools in tools/:
- gerrit-pre-push-lint: Checks for issues reviewers commonly flag (missing release notes, bug references, YAML line length, Jinja2 spacing, changed_when misuse, etc.). Supports --stack and --range for checking multiple commits.
- analyze-gerrit-review-times: Analyzes reviewer activity patterns to find optimal posting times.
- analyze-gerrit-patch-size: Analyzes how patch size and series length correlate with review response.
- analyze-gerrit-new-roles: Analyzes patterns for new role additions.

New documentation in docs/:
- gerrit-api.md: Reference for Gerrit SSH and REST APIs.
- tactics.md: Tactical advice for getting patches reviewed quickly, based on analysis of 200+ merged reviews.

Also updated CLAUDE.md and README.md.tmpl to document the new tools.

Prompt: Analyze Gerrit reviews from review.opendev.org for Kolla and Kolla-Ansible projects to identify common review feedback patterns, then build a linter to catch issues before pushing changes. Also document the Gerrit APIs and analyze optimal posting strategies.