### PR TITLE
Exclude data/ and docs/ from all PR workflows.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -7,6 +7,7 @@ on:
       - develop
     paths-ignore:
       - 'data/**'
+      - 'docs/**'
 
 jobs:
   lint:

--- a/.github/workflows/local-container-builds.yml
+++ b/.github/workflows/local-container-builds.yml
@@ -13,6 +13,9 @@ on:
   pull_request:
     branches:
       - develop
+    paths-ignore:
+      - 'data/**'
+      - 'docs/**'
 
 jobs:
   local_build_matrix:

--- a/.github/workflows/rebase-tests.yml
+++ b/.github/workflows/rebase-tests.yml
@@ -10,6 +10,7 @@ on:
       - develop
       - v*-releases
     paths-ignore:
+      - 'data/**'
       - 'docs/**'
 
 jobs:


### PR DESCRIPTION
Add consistent paths-ignore rules to all three PR-triggered workflows to prevent unnecessary CI runs when only data/ or docs/ files change. This breaks the infinite loop where layer data PRs trigger more builds.

Prompt: CI run for PR 801 should not have triggered the functional tests, as the data directory is meant to be excluded. Why is it still running? Also make docs/ exclusion consistent across workflows.