### PR TITLE
Add upstream commit summary to daily rebase PRs.

### DIFF
--- a/.github/workflows/daily-rebase-checks.yml
+++ b/.github/workflows/daily-rebase-checks.yml
@@ -45,7 +45,8 @@ jobs:
           sed "s/%%date%%/${DATEPRETTY}/" README.md.tmpl > README.md
 
           # Lock in new daily SHAs
-          _build/bump-source-shas.sh 1
+          _build/bump-source-shas.sh 1 \
+              --changelog ${GITHUB_WORKSPACE}/sha-changelog.txt
 
           echo
           echo "Changes..."
@@ -124,6 +125,17 @@ jobs:
           git push -f origin daily-rebase-${DATESTAMP}
           sleep 10
 
+          # Build upstream changes summary
+          changelog=""
+          if [ -s ${GITHUB_WORKSPACE}/sha-changelog.txt ]; then
+            changelog="
+
+          **Upstream changes:**
+          \`\`\`
+          $(cat ${GITHUB_WORKSPACE}/sha-changelog.txt)
+          \`\`\`"
+          fi
+
           # Determine PR body based on what happened
           if [ "${{ steps.rebase.outputs.patches_failed }}" == "true" ]; then
             if [ "${{ steps.rebase.outputs.fix_succeeded }}" == "true" ]; then
@@ -132,17 +144,17 @@ jobs:
           **Note:** Some patches failed to apply with the new upstream SHAs.
           Claude Code automatically fixed the patches.
 
-          Please review the patch changes carefully before merging."
+          Please review the patch changes carefully before merging.${changelog}"
             else
               pr_body="A daily rebase was attempted.
 
           **Warning:** Some patches failed to apply and Claude Code was
           unable to fix them automatically. Manual intervention is required.
 
-          See the workflow logs for details about which patches failed."
+          See the workflow logs for details about which patches failed.${changelog}"
             fi
           else
-            pr_body="A daily rebase was attempted. All patches applied successfully."
+            pr_body="A daily rebase was attempted. All patches applied successfully.${changelog}"
           fi
 
           echo "Create a PR..."

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,150 @@
+# Architecture
+
+Kerbside-patches is a patch management and container build
+system for OpenStack components. It maintains patches that
+enable native SPICE console support and builds Kolla
+container images with those patches applied.
+
+## Directory Structure
+
+```
+kerbside-patches/
+    .github/
+        workflows/
+            functional-tests.yml  # CI: build, deploy, test
+            daily-rebase-checks.yml  # Daily upstream rebase
+    _build/                  # Build and CI scripts
+        common.sh            # Shared functions and CLI parsing
+        assemble-source.sh   # Clone repos, apply patches
+        build-containers.sh  # Build + push images via occystrap
+        imagebuild.sh        # Run kolla-build
+        imagearchive.sh      # Archive images with SBOMs
+        test-apply.sh        # Test patch application
+        test-patches-for-ci.sh  # CI-friendly patch testing
+        rebase-with-claude.sh   # Automated rebase with Claude
+        bump-source-shas.sh    # Update upstream SHAs
+    _patches/                # All patch files (shared pool)
+        patchNNN-desc.patch  # Patch files
+        patchNNN-desc.patch-message  # Optional commit messages
+    data/                    # Layer data tarballs from CI
+    docs/                    # Additional documentation
+    tools/                   # Utility scripts
+        summarize_layers.py  # Layer data analysis
+        find_images           # GitLab registry image finder
+        gerrit-pre-push-lint  # Gerrit pre-push linter
+    kolla/                   # Kolla master patches
+    kolla-2025.1/            # Kolla epoxy patches
+    kolla-2025.2/            # Kolla flamingo patches
+    kolla-ansible/           # Kolla-Ansible master patches
+    kolla-ansible-2025.1/    # Kolla-Ansible epoxy patches
+    kolla-ansible-2025.2/    # Kolla-Ansible flamingo patches
+    nova-2025.1/             # Nova epoxy patches
+    globals.yml              # Kolla-Ansible deployment config
+    README.md.tmpl           # README template (edit this)
+    README.md                # Generated README (do not edit)
+```
+
+## Patch System
+
+### Project Directories
+
+Each `<project>[-<version>]/` directory contains:
+
+- `config.yaml` -- repo URL, branch, source SHA, release
+  name, dependencies
+- `ORDER` -- ordered list of patches to apply from
+  `_patches/`
+- `FORCE` (optional) -- forces inclusion even with no
+  patches
+
+### Patch Application Flow
+
+```
+config.yaml (repo + SHA)
+    |
+    v
+git clone + checkout SHA
+    |
+    v
+ORDER file (list of patches)
+    |
+    v
+git apply each patch in order
+    |
+    v
+optionally run test suites
+```
+
+### Shared Patches
+
+Patches in `_patches/` can be referenced by multiple ORDER
+files across releases. When a patch needs release-specific
+changes, a copy is created with a release codename in the
+filename.
+
+## Container Build Pipeline
+
+### Build Flow
+
+```
+assemble-source.sh (clone + patch)
+    |
+    v
+imagebuild.sh (kolla-build)
+    |
+    v
+build-containers.sh (push via occystrap)
+    |
+    v
+occystrap pipeline:
+    inspect (as-built)
+        -> normalize-timestamps
+    inspect (post-normalize)
+        -> exclude .git
+    inspect (post-exclude)
+        -> registry push
+```
+
+### Layer Data Collection
+
+The occystrap inspect filter records layer metadata (digest,
+size, history) at each pipeline stage. This produces per-image
+JSONL files that are packaged into a tarball.
+
+Data flow:
+1. occystrap writes per-image JSONL files during push
+2. Files are tarred into `layers.tar.gz`
+3. CI uploads as build artifact
+4. `collect_layer_data` job aggregates across matrix builds
+5. Tarballs are committed to `data/` via automated PR
+
+### Analysis
+
+`tools/summarize_layers.py` processes the tarballs:
+
+- `--data-dir` -- chronological build progression, tracking
+  layer reuse across builds
+- `--compare-stages` -- per-stage comparison showing how
+  each filter affects layer count and size
+- `--stage` -- select a specific pipeline stage for analysis
+
+## CI/CD
+
+### Functional Tests Workflow
+
+The main CI workflow (`functional-tests.yml`) runs on PRs:
+
+1. **build** (matrix) -- builds container images for each
+   target release and distro combination
+2. **deploy** -- deploys OpenStack via kolla-ansible and
+   runs functional tests (VM creation, console access)
+3. **collect_layer_data** -- aggregates layer tarballs and
+   proposes a PR to store them in `data/`
+
+### Daily Rebase
+
+`daily-rebase-checks.yml` runs daily to keep patches current
+with upstream. It updates source SHAs, tests patches, and
+uses Claude Code to auto-fix failures when possible. The
+resulting PR includes a summary of upstream commits pulled
+in for each project (short hashes and oneline messages).

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ directories. This section documents each script and its purpose.
 | Script | Description |
 |--------|-------------|
 | `rebase-with-claude.sh [options] [projects...]` | Unified rebase helper for both CI and CLI use. Tests patches, analyzes failures, and invokes Claude Code to auto-fix. Options: `--bump-shas` (update to HEAD), `--step-forward N` (advance N commits from current), `--no-claude`, `--interactive`, `--ci`. |
-| `bump-source-shas.sh [N]` | Updates `source_sha` in all project `config.yaml` files. With a positional arg N, sets to the Nth most recent upstream commit (default: 1 = HEAD). With `--forward N`, steps forward N commits from the current SHA. |
+| `bump-source-shas.sh [N]` | Updates `source_sha` in all project `config.yaml` files. With a positional arg N, sets to the Nth most recent upstream commit (default: 1 = HEAD). With `--forward N`, steps forward N commits from the current SHA. With `--changelog <path>`, writes a per-project summary of new upstream commits (short hashes + oneline messages) to the specified file. |
 | `analyze-shared-patches.py <results.json>` | Analyzes failing patches to determine fix strategy (`modify_in_place` vs `create_copy`) based on whether patches are shared across releases. |
 | `find-patch-usage.py <patch-file>` | Finds all ORDER files that reference a given patch. Returns JSON with list of projects using the patch. |
 | `get-next-patch-number.py` | Returns the next available patch number by checking both existing files in `_patches/` and open GitHub PRs. |

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -223,7 +223,7 @@ directories. This section documents each script and its purpose.
 | Script | Description |
 |--------|-------------|
 | `rebase-with-claude.sh [options] [projects...]` | Unified rebase helper for both CI and CLI use. Tests patches, analyzes failures, and invokes Claude Code to auto-fix. Options: `--bump-shas` (update to HEAD), `--step-forward N` (advance N commits from current), `--no-claude`, `--interactive`, `--ci`. |
-| `bump-source-shas.sh [N]` | Updates `source_sha` in all project `config.yaml` files. With a positional arg N, sets to the Nth most recent upstream commit (default: 1 = HEAD). With `--forward N`, steps forward N commits from the current SHA. |
+| `bump-source-shas.sh [N]` | Updates `source_sha` in all project `config.yaml` files. With a positional arg N, sets to the Nth most recent upstream commit (default: 1 = HEAD). With `--forward N`, steps forward N commits from the current SHA. With `--changelog <path>`, writes a per-project summary of new upstream commits (short hashes + oneline messages) to the specified file. |
 | `analyze-shared-patches.py <results.json>` | Analyzes failing patches to determine fix strategy (`modify_in_place` vs `create_copy`) based on whether patches are shared across releases. |
 | `find-patch-usage.py <patch-file>` | Finds all ORDER files that reference a given patch. Returns JSON with list of projects using the patch. |
 | `get-next-patch-number.py` | Returns the next available patch number by checking both existing files in `_patches/` and open GitHub PRs. |

--- a/_build/bump-source-shas.sh
+++ b/_build/bump-source-shas.sh
@@ -5,6 +5,7 @@
 # Usage:
 #   bump-source-shas.sh [N]           # Set to HEAD~(N-1), default N=1 (HEAD)
 #   bump-source-shas.sh --forward N   # Step forward N commits from current SHA
+#   bump-source-shas.sh --changelog F # Write per-project commit summary to F
 #
 # Examples:
 #   bump-source-shas.sh               # Update to latest HEAD
@@ -12,9 +13,11 @@
 #   bump-source-shas.sh 5             # Update to HEAD~4 (5 back from tip)
 #   bump-source-shas.sh --forward 1   # Step forward 1 commit from current
 #   bump-source-shas.sh --forward 10  # Step forward 10 commits from current
+#   bump-source-shas.sh --changelog /tmp/changes.md
 
 mode="rewind"
 count=1
+changelog_path=""
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -24,8 +27,12 @@ while [[ $# -gt 0 ]]; do
             count="$2"
             shift 2
             ;;
+        --changelog|-c)
+            changelog_path="$2"
+            shift 2
+            ;;
         --help|-h)
-            head -15 "$0" | tail -13
+            head -17 "$0" | tail -15
             exit 0
             ;;
         *)
@@ -35,6 +42,11 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# Initialize changelog file if requested
+if [ -n "${changelog_path}" ]; then
+    true > "${changelog_path}"
+fi
 
 if [ "${mode}" = "rewind" ]; then
     echo "Mode: rewind - will set to HEAD~$((count - 1)) (${count} back from tip)"
@@ -85,6 +97,19 @@ for project in ${projects}; do
         else
             source_sha=$(echo "${commits_ahead}" | head -${count} | tail -1)
         fi
+    fi
+
+    # Generate changelog before deleting the clone
+    if [ -n "${changelog_path}" ] \
+            && [ "${source_sha}" != "${current_source_sha}" ]; then
+        short_old=$(echo "${current_source_sha}" | cut -c1-9)
+        short_new=$(echo "${source_sha}" | cut -c1-9)
+        {
+            echo "${project} updated from ${short_old} to ${short_new}"
+            git log --oneline "${current_source_sha}..${source_sha}" \
+                | sed 's/^/    /'
+            echo
+        } >> "${changelog_path}"
     fi
 
     cd ${cwd}


### PR DESCRIPTION
bump-source-shas.sh now accepts --changelog <path> to write a per-project summary of new upstream commits (short hashes and oneline messages). The daily rebase workflow passes this option and includes the resulting summary in the PR body, so reviewers can see at a glance what changed upstream.

Prompt: It occurs to me it would be super nice if the pull request included a little summary of what commits had just been pulled in for a given repository.