### PR TITLE
Use shared deploy action, add downstream trigger.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -1015,6 +1015,9 @@ jobs:
           git checkout develop
           git checkout -b "${branch_name}"
 
+          # Ensure data/ exists
+          mkdir data
+
           # Copy layer tarballs with unique names (only from current attempt)
           mkdir -p data
           for dir in /tmp/build-artifacts/build-*/; do

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -608,59 +608,16 @@ jobs:
               ${{ matrix.test.baseuser }}@10.0.2.2 \
               "cd /srv/shakenfist/kerbside-patches && tar xzf -"
 
-      - name: Bootstrap Kolla-Ansible
-        env:
-          CI_REGISTRY_TOKEN: ${{ secrets.CI_REGISTRY_TOKEN }}
-        run: |
-          . $GITHUB_ENV
-
-          script="cd /srv/shakenfist/kerbside-patches;"
-          script="${script} sudo ./tools/bootstrap-kolla-ansible"
-              script="${script} --registry-token ${CI_REGISTRY_TOKEN}"
-              script="${script} --image-tag ${{ steps.incoming.outputs.image_tag }}"
-              script="${script} --build-targets ${{ matrix.test.release }}"
-
-          if [ ${{ matrix.test.enable_kerbside }} != "true" ]; then
-              script="${script} --disable-kerbside"
-          fi
-
-          script="${script} --topology ${{ matrix.test.topology }};"
-
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.test.baseuser }}@10.0.2.2 "${script}"
-
-      - name: Run pre-checks
-        run: |
-          . $GITHUB_ENV
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.test.baseuser }}@10.0.2.2 \
-              'cd /srv/shakenfist/kerbside-patches; sudo ./tools/ka prechecks -i /etc/kolla/inventory'
-
-      - name: Pull images
-        run: |
-          . $GITHUB_ENV
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.test.baseuser }}@10.0.2.2 \
-              'cd /srv/shakenfist/kerbside-patches; sudo ./tools/ka pull -i /etc/kolla/inventory'
-
-      - name: Deploy
-        run: |
-          . $GITHUB_ENV
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.test.baseuser }}@10.0.2.2 \
-              'cd /srv/shakenfist/kerbside-patches; sudo ./tools/ka deploy -i /etc/kolla/inventory'
-
-      - name: Install patched clients
-        run: |
-          . $GITHUB_ENV
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.test.baseuser }}@10.0.2.2 \
-              'cd /srv/shakenfist/kerbside-patches; sudo ./tools/install-openstack-clients'
+      - name: Deploy Kolla-Ansible
+        uses: shakenfist/actions/deploy-kolla-ansible@main
+        with:
+          base_user: ${{ matrix.test.baseuser }}
+          image_tag: ${{ steps.incoming.outputs.image_tag }}
+          build_targets: ${{ matrix.test.release }}
+          topology: ${{ matrix.test.topology }}
+          registry_token: ${{ secrets.CI_REGISTRY_TOKEN }}
+          enable_kerbside: ${{ matrix.test.enable_kerbside }}
+          use_ci_registry: 'true'
 
       - name: Dump internal VIP CA cert details
         if: always()
@@ -679,14 +636,6 @@ jobs:
               -o UserKnownHostsFile=/dev/null \
               ${{ matrix.test.baseuser }}@10.0.2.2 \
               'sudo openssl storeutl -noout -text -certs /etc/kolla/certificates/ca/root.crt'
-
-      - name: Post install Kolla-Ansible setup
-        run: |
-          . $GITHUB_ENV
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.test.baseuser }}@10.0.2.2 \
-              'cd /srv/shakenfist/kerbside-patches; sudo ./tools/postinstall-kolla-ansible --use-ci-registry'
 
       - name: Verify that the haproxy is configured correctly for the Kerbside API
         run: |

--- a/.github/workflows/trigger-downstream.yml
+++ b/.github/workflows/trigger-downstream.yml
@@ -1,0 +1,19 @@
+name: Trigger downstream CI
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  trigger-kerbside:
+    runs-on: [self-hosted, static]
+    timeout-minutes: 5
+    steps:
+      - name: Trigger kerbside cloud compatibility tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.DAILY_REBASE_TOKEN }}
+        run: |
+          gh workflow run "Test cloud compatibility" \
+              --repo shakenfist/kerbside \
+              -f target='["kolla-ansible-master-debian-12"]'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,9 +56,22 @@ via occystrap's inspect filter. Data flows:
 The main workflow is `.github/workflows/functional-tests.yml`.
 It is large and has several jobs:
 
-- `build` -- builds container images (matrix strategy)
-- `deploy` -- deploys with kolla-ansible and runs tests
+- `build_images` -- builds container images (matrix strategy)
+- `test_installs` -- deploys with kolla-ansible and runs tests
 - `collect_layer_data` -- aggregates layer data from builds
+
+The deploy steps (bootstrap, prechecks, pull, deploy,
+install-clients, post-install) are shared with kerbside's
+CI via the `shakenfist/actions/deploy-kolla-ansible` composite
+action. Changes to the deploy flow should be made in that
+action, not inlined in the workflow.
+
+Other workflows:
+- `trigger-downstream.yml` -- triggers kerbside CI on push
+  to develop (e.g. after daily rebase PR merges)
+- `local-container-builds.yml` -- tests local builds work
+- `daily-rebase-checks.yml` -- daily upstream rebase with
+  Claude-assisted patch fixing
 
 **Runner types and constraints:**
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,6 +13,8 @@ kerbside-patches/
         workflows/
             functional-tests.yml  # CI: build, deploy, test
             daily-rebase-checks.yml  # Daily upstream rebase
+            trigger-downstream.yml  # Trigger kerbside CI on develop push
+            local-container-builds.yml  # Test local builds work
     _build/                  # Build and CI scripts
         common.sh            # Shared functions and CLI parsing
         assemble-source.sh   # Clone repos, apply patches

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -267,6 +267,12 @@ directories. This section documents each script and its purpose.
 | `gather-logs` | Collects logs from Kolla containers for debugging. |
 | `spice-connect.py` | Python script for testing SPICE console connections programmatically. |
 
+### Layer Analysis Tools
+
+| Script | Description |
+|--------|-------------|
+| `summarize_layers.py` | Analyzes Docker image layer data collected from CI builds. Layer data is stored as `.tar.gz` tarballs containing per-image JSONL files organized by pipeline stage. Use `-d data/` for chronological build progression analysis, `--stage` to select a pipeline stage (default: `post-exclude`), and `--compare-stages` to compare the effect of each optimization filter. |
+
 ### Pre-Push Linting for Gerrit
 
 | Script | Description |

--- a/_build/imagebuild.sh
+++ b/_build/imagebuild.sh
@@ -13,6 +13,13 @@ for target in ${build_targets}; do
     declare -a directories
     directories+=(kerbside)
 
+    # Ensure kerbside source is available (assemble-source.sh tars and
+    # removes directories)
+    if [ ! -d ${topsrcdir}/kerbside ] && [ -f ${topsrcdir}/kerbside.tgz ]; then
+        echo "Extracting kerbside archive"
+        tar xzf ${topsrcdir}/kerbside.tgz -C ${topsrcdir}/
+    fi
+
     projects=$(find . -type f -name "config.yaml" | cut -f 2 -d "/")
     for project in ${projects}; do
         echo -e "${H3}Considering ${project}${Color_Off}"


### PR DESCRIPTION
Replace inlined Kolla-Ansible deploy steps in
test_installs with the new composite action from
shakenfist/actions/deploy-kolla-ansible.

Add trigger-downstream.yml workflow to trigger
kerbside CI when code is pushed to develop (e.g.
after the daily rebase PR merges), replacing the
need for a fixed daily schedule in kerbside.

Update AGENTS.md, ARCHITECTURE.md, and README.md.tmpl to document the new workflow and shared action.

Prompt: Fix the kerbside CI Kolla-Ansible build by sharing deploy steps via a composite action in the shakenfist/actions repo.