### PR TITLE
Fix empty docker_registry_password in CI.

### DIFF
--- a/tools/bootstrap-kolla-ansible
+++ b/tools/bootstrap-kolla-ansible
@@ -159,10 +159,14 @@ echo -e "${H2}Generate passwords${Color_Off}"
 kolla-genpwd
 echo
 
-echo -e "${H2}Add docker registry password${Color_Off}"
-grep -v "docker_registry_password" /etc/kolla/passwords.yml > /etc/kolla/passwords.yml.new
-echo "docker_registry_password: ${registry_token}" >> /etc/kolla/passwords.yml.new
-mv /etc/kolla/passwords.yml.new /etc/kolla/passwords.yml
+if [ -n "${registry_token}" ]; then
+    echo -e "${H2}Add docker registry password${Color_Off}"
+    grep -v "docker_registry_password" /etc/kolla/passwords.yml > /etc/kolla/passwords.yml.new
+    echo "docker_registry_password: ${registry_token}" >> /etc/kolla/passwords.yml.new
+    mv /etc/kolla/passwords.yml.new /etc/kolla/passwords.yml
+else
+    echo -e "${H2}No registry token provided, keeping genpwd docker registry password${Color_Off}"
+fi
 echo
 
 echo -e "${H2}Make certificates${Color_Off}"


### PR DESCRIPTION
When no --registry-token is provided (e.g. kerbside CI using locally built images), the bootstrap script was unconditionally replacing the kolla-genpwd generated docker_registry_password with an empty value. This caused kolla-ansible prechecks to fail with "Checking empty passwords in passwords.yml".

Only replace docker_registry_password when a registry token is actually provided. Otherwise keep the random password that kolla-genpwd generated.

Prompt: Fix genpwd password setup failure in kerbside functional CI where docker_registry_password was empty.