### PR TITLE
Strip CI registry from globals.yml for local builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ directories. This section documents each script and its purpose.
 
 | Script | Description |
 |--------|-------------|
-| `bootstrap-kolla-ansible` | Bootstraps Kolla-Ansible into a virtualenv and prepares for deployment. |
+| `bootstrap-kolla-ansible` | Bootstraps Kolla-Ansible into a virtualenv and prepares for deployment. When `--use-ci-registry` is not passed, strips CI registry settings from `globals.yml` so Kolla-Ansible uses local images. |
 | `postinstall-kolla-ansible` | Post-installation tasks after Kolla-Ansible deployment. |
 | `install-openstack-clients` | Installs patched OpenStack clients (openstacksdk, python-openstackclient) from source. |
 | `ka` | Shortcut wrapper for running kolla-ansible commands. |

--- a/tools/bootstrap-kolla-ansible
+++ b/tools/bootstrap-kolla-ansible
@@ -100,6 +100,13 @@ cat etc/globals-${target_release}.yml | \
     sed "s/ENABLE_KERBSIDE/${enable_kerbside}/" | \
     sed "s/IMAGE_TAG/${image_tag}/" \
     > /etc/kolla/globals.yml
+
+if [ "${use_ci_registry}" != "true" ]; then
+    echo -e "${H2}Not using CI registry, removing registry settings${Color_Off}"
+    sed -i '/^docker_registry:/d' /etc/kolla/globals.yml
+    sed -i '/^docker_registry_insecure:/d' /etc/kolla/globals.yml
+    sed -i '/^docker_registry_username:/d' /etc/kolla/globals.yml
+fi
 echo
 
 sed -i "s/127.0.0.1 kolla.local kolla//" /etc/hosts


### PR DESCRIPTION
When use_ci_registry is not set, bootstrap-kolla-ansible now removes docker_registry, docker_registry_insecure, and docker_registry_username from globals.yml. This prevents Kolla-Ansible from trying to authenticate to the CI registry when container images are built locally, fixing 403 errors during deploy.

Prompt: The CI run in Kerbside is failing because it cannot authenticate to the CI OCI registry, but it shouldn't need to given we build the container images locally. I think perhaps we've set the registry to the CI one somewhere we shouldn't have.