### PR TITLE
Reset docker_namespace for local builds.

### DIFF
--- a/tools/bootstrap-kolla-ansible
+++ b/tools/bootstrap-kolla-ansible
@@ -106,6 +106,7 @@ if [ "${use_ci_registry}" != "true" ]; then
     sed -i '/^docker_registry:/d' /etc/kolla/globals.yml
     sed -i '/^docker_registry_insecure:/d' /etc/kolla/globals.yml
     sed -i '/^docker_registry_username:/d' /etc/kolla/globals.yml
+    sed -i 's|^docker_namespace:.*|docker_namespace: "kolla"|' /etc/kolla/globals.yml
 fi
 echo
 


### PR DESCRIPTION
When not using the CI registry, bootstrap-kolla-ansible removed docker_registry but left docker_namespace set to the CI registry path "openstack/kolla-images". Without an explicit docker_registry, kolla-ansible defaults to quay.io, producing image references like
quay.io/openstack/kolla-images/<image>:local which don't exist. Reset docker_namespace to "kolla" to match the namespace used by kolla-build for local image builds.

Prompt: Fix docker registry issues in kerbside CI where locally built container images aren't found because kolla-ansible tries to pull from quay.io instead.