### PR TITLE
Bump shas manually, handle influx removal.

### DIFF
--- a/_patches/patch047-kolla-fluentd-enable-syslog.patch
+++ b/_patches/patch047-kolla-fluentd-enable-syslog.patch
@@ -1,6 +1,6 @@
-commit a9d2aac3f19610e8fbeeb498eb57788e411880f1
+commit 979e123d3b7e05d3820bc483b773a40b8265c3e3
 Author: Michael Still <mikal@stillhq.com>
-Date:   Tue Feb 3 08:34:37 2026 +1100
+Date:   Sun Mar 15 09:44:33 2026 +1100
 
     Add syslog to fluentd.
     

--- a/_patches/patch064-allow-rocky-10-builds.patch
+++ b/_patches/patch064-allow-rocky-10-builds.patch
@@ -1,6 +1,6 @@
-commit 0c652efaa22cd957c3db4ee51ab1ab7a9cd5d1ce
+commit 369f471220390e4787be06cc4819ab4995fdced1
 Author: Michael Still <mikal@stillhq.com>
-Date:   Mon Feb 2 10:05:54 2026 +1100
+Date:   Sun Mar 15 09:44:23 2026 +1100
 
     Allow Rocky 10 installs.
     

--- a/_patches/patch093-kolla-master-compressed.patch
+++ b/_patches/patch093-kolla-master-compressed.patch
@@ -1,6 +1,6 @@
-commit bb89bff00402d5dda660cbdd606410afefd83f65
+commit 2cd0e857e5a0b399ffc5596dec71117929108680
 Author: Michael Still <mikal@stillhq.com>
-Date:   Mon Feb 16 14:21:58 2026 +1100
+Date:   Sun Mar 15 09:44:33 2026 +1100
 
     Implement container image build for kerbside.
     
@@ -33,10 +33,10 @@ Date:   Mon Feb 16 14:21:58 2026 +1100
     Signed-off-by: Michael Still <mikal@stillhq.com>
 
 diff --git a/doc/source/support_matrix.rst b/doc/source/support_matrix.rst
-index 445ed08c6..940a519d4 100644
+index 31c67e70a..b1ab1e671 100644
 --- a/doc/source/support_matrix.rst
 +++ b/doc/source/support_matrix.rst
-@@ -89,3 +89,12 @@ Currently unbuildable images
+@@ -105,3 +105,12 @@ Currently unbuildable images
  
  For a list of currently unbuildable images please look into
  ``kolla/image/unbuildable.py`` file - ``UNBUILDABLE_IMAGES`` dictionary.

--- a/_patches/patch108-dry-up-logrotate-cron.patch
+++ b/_patches/patch108-dry-up-logrotate-cron.patch
@@ -1,6 +1,6 @@
-commit 7058da05c300b371deb4563b51d6a2742397b4b4
+commit 3b05919c256b590349c38c16c977fb6147255a53
 Author: Michael Still <mikal@stillhq.com>
-Date:   Mon Feb 16 14:21:30 2026 +1100
+Date:   Sun Mar 15 09:44:23 2026 +1100
 
     Simplify cron jobs for log rotate.
     
@@ -202,15 +202,6 @@ index f346694f4..000000000
 +++ /dev/null
 @@ -1,3 +0,0 @@
 -"/var/log/kolla/horizon/*.log"
--{
--}
-diff --git a/ansible/roles/cron/templates/cron-logrotate-influxdb.conf.j2 b/ansible/roles/cron/templates/cron-logrotate-influxdb.conf.j2
-deleted file mode 100644
-index 8a25646d3..000000000
---- a/ansible/roles/cron/templates/cron-logrotate-influxdb.conf.j2
-+++ /dev/null
-@@ -1,3 +0,0 @@
--"/var/log/kolla/influxdb/*.log"
 -{
 -}
 diff --git a/ansible/roles/cron/templates/cron-logrotate-ironic.conf.j2 b/ansible/roles/cron/templates/cron-logrotate-ironic.conf.j2

--- a/_patches/patch121-kolla-ansible-master-support-secure-spice.patch
+++ b/_patches/patch121-kolla-ansible-master-support-secure-spice.patch
@@ -1,6 +1,6 @@
-commit 9161d793525fd85a18f3a52fe0758ea9e2aae2c8
+commit 064ea5c3dd32ddf9e7ae53f3471e2c06bd62bebe
 Author: Michael Still <mikal@stillhq.com>
-Date:   Mon Feb 16 14:21:05 2026 +1100
+Date:   Sun Mar 15 09:44:23 2026 +1100
 
     Allow requiring secure channels with SPICE.
     

--- a/_patches/patch123-kolla-ansible-master-expose-spice-configuration.patch
+++ b/_patches/patch123-kolla-ansible-master-expose-spice-configuration.patch
@@ -1,6 +1,6 @@
-commit a1b289b48cc86c22ac2547b1c28c559ab7f6c669
+commit 8237c8e14570bb117638c7dd140555bb10f0bfda
 Author: Michael Still <mikal@stillhq.com>
-Date:   Mon Feb 16 14:21:05 2026 +1100
+Date:   Sun Mar 15 09:44:23 2026 +1100
 
     Add additional SPICE configuration options.
     
@@ -75,7 +75,7 @@ index b997c671e..d62a1eaf4 100644
      - haproxy_stat.find('nova_spicehtml5proxy') == -1
      - haproxy_vip_prechecks
 diff --git a/ansible/roles/nova-cell/defaults/main.yml b/ansible/roles/nova-cell/defaults/main.yml
-index aa1d57180..953a61790 100644
+index ce66c7015..6979408e9 100644
 --- a/ansible/roles/nova-cell/defaults/main.yml
 +++ b/ansible/roles/nova-cell/defaults/main.yml
 @@ -33,7 +33,7 @@ nova_cell_services:

--- a/_patches/patch134-kolla-ansible-master-allow-concurrent-spice-connections.patch
+++ b/_patches/patch134-kolla-ansible-master-allow-concurrent-spice-connections.patch
@@ -1,6 +1,6 @@
-commit 3d9b3d26e7ca13936204c721a4c148ce2c5831cf
+commit ae740e1f82ee5ca74840496c63f66e8b272538c2
 Author: Michael Still <mikal@stillhq.com>
-Date:   Mon Feb 2 10:05:55 2026 +1100
+Date:   Sun Mar 15 09:44:23 2026 +1100
 
     Allow concurrent sessions with SPICE.
     
@@ -26,7 +26,7 @@ index 9c98dc933..7efa84210 100644
  nova_spice_require_secure: false
 +nova_spice_allow_concurrent: true
 diff --git a/ansible/roles/nova-cell/templates/nova.conf.j2 b/ansible/roles/nova-cell/templates/nova.conf.j2
-index a4e181273..cbbccad4e 100644
+index 6fb4641ad..e9f153283 100644
 --- a/ansible/roles/nova-cell/templates/nova.conf.j2
 +++ b/ansible/roles/nova-cell/templates/nova.conf.j2
 @@ -62,6 +62,7 @@ enabled = false

--- a/_patches/patch138-kolla-pin-setuptools.patch
+++ b/_patches/patch138-kolla-pin-setuptools.patch
@@ -1,20 +1,20 @@
-commit c7654a2bc5c6679cd5052b360cf7b4920edead9c
+commit ff2a6682468dcc6614a8a4848916ed4bd2931354
 Author: Michael Still <mikal@stillhq.com>
-Date:   Mon Feb 9 18:35:54 2026 +1100
+Date:   Sun Mar 15 09:44:32 2026 +1100
 
     Setuptools released v82.0.0 which does not have pkg_resources.
-
+    
     Pin setuptools in test-requirements.txt as well. The requirements.txt
     pin is already present upstream.
-
+    
     Change-Id: I55851cb5d8f0bb089bd9f49e70bb18a5f270573a
     Signed-off-by: Michael Still <mikal@stillhq.com>
 
 diff --git a/test-requirements.txt b/test-requirements.txt
-index 25be6288e..63fdfa4cc 100644
+index 7e3178bd6..da07ce638 100644
 --- a/test-requirements.txt
 +++ b/test-requirements.txt
-@@ -10,3 +10,4 @@ hacking>=7.0.0,<=7.1.0 # Apache-2.0
+@@ -11,3 +11,4 @@ hacking>=7.0.0,<=7.1.0 # Apache-2.0
  oslotest>=3.2.0 # Apache-2.0
  stestr>=2.2.0 # Apache-2.0
  testtools>=2.2.0 # MIT

--- a/_patches/patch142-kolla-ansible-kerbside-role.patch
+++ b/_patches/patch142-kolla-ansible-kerbside-role.patch
@@ -394,7 +394,7 @@ new file mode 100644
 index 000000000..5d9b565de
 --- /dev/null
 +++ b/ansible/roles/kerbside/defaults/main.yml
-@@ -0,0 +1,157 @@
+@@ -0,0 +1,161 @@
 +---
 +kerbside_services:
 +  kerbside_api:
@@ -486,7 +486,11 @@ index 000000000..5d9b565de
 +kerbside_healthcheck_start_period: "{{ default_container_healthcheck_start_period }}"
 +kerbside_healthcheck_timeout: "{{ default_container_healthcheck_timeout }}"
 +
-+kerbside_api_healthcheck_test: ["CMD-SHELL", "healthcheck_curl {{ 'https' if kerbside_enable_tls_backend | bool else 'http' }}://{{ api_interface_address | put_address_in_context('url') }}:{{ kerbside_api_listen_port }} "]
++kerbside_api_healthcheck_test:
++  - "CMD-SHELL"
++  - >-
++    healthcheck_curl {{ 'https' if kerbside_enable_tls_backend | bool else 'http' }}://{{
++    api_interface_address | put_address_in_context('url') }}:{{ kerbside_api_listen_port }}
 +kerbside_proxy_healthcheck_test: ["CMD-SHELL", "healthcheck_listen kerbside {{ kerbside_vdi_secure_listen_port }}"]
 +
 +kerbside_healthcheck_api:

--- a/_patches/patch142-kolla-ansible-kerbside-role.patch
+++ b/_patches/patch142-kolla-ansible-kerbside-role.patch
@@ -1,19 +1,19 @@
-commit 03b107df1ba658e049cdc8becb7abce88c16f4a4
+commit 1985fc69b3eeb30d740676d75779ff2c6b75ff00
 Author: Michael Still <mikal@stillhq.com>
-Date:   Mon Feb 16 14:30:54 2026 +1100
+Date:   Sun Mar 15 09:44:23 2026 +1100
 
     Deploy Kerbside with Kolla-Ansible.
-
+    
     This change implements the Kerbside Kolla-Ansible deployment role. It is a
     fairly large change, but I couldn't find a meaningful way to break it up
     into smaller chunks.
-
+    
     The basic idea is that there is a proxy sitting in front of the Nova
     hypervisors that can talk the SPICE protocol to clients, lookup where the
     console is on the relevant hypervisor, and then build a SPICE connection
     to that hypervisor. It then shovels SPICE packets back and forth between
     the two.
-
+    
     That proxy is called Kerbside and it consists of two components which
     each have their own Kolla container. kerbside-api handles business logic
     and is a uwsgi app. kerbside-proxy is the SPICE native component. Because
@@ -63,7 +63,7 @@ index 000000000..da4d90b1e
 +kerbside_safety_upgrade: false
 +kerbside_enable_tls_backend: true
 diff --git a/ansible/inventory/all-in-one b/ansible/inventory/all-in-one
-index e4b5fb495..a69403660 100644
+index ce3b26f16..0394e0d94 100644
 --- a/ansible/inventory/all-in-one
 +++ b/ansible/inventory/all-in-one
 @@ -18,6 +18,9 @@ localhost       ansible_connection=local
@@ -84,20 +84,10 @@ index e4b5fb495..a69403660 100644
  
  [collectd:children]
  compute
-@@ -50,6 +54,7 @@ control
- monitoring
- network
- storage
-+vdiproxy
+@@ -585,3 +589,10 @@ letsencrypt
  
- [hacluster:children]
- control
-@@ -230,6 +235,16 @@ nova
- [nova-serialproxy:children]
- nova
- 
-+[kerbside-proxy:children]
-+nova
+ [letsencrypt-lego:children]
+ letsencrypt
 +
 +# Kerbside
 +[kerbside-api:children]
@@ -105,12 +95,8 @@ index e4b5fb495..a69403660 100644
 +
 +[kerbside-proxy:children]
 +vdiproxy
-+
- # Neutron
- [ironic-neutron-agent:children]
- neutron
 diff --git a/ansible/inventory/multinode b/ansible/inventory/multinode
-index 3a3db6f29..8fa6a9889 100644
+index 40db78c1e..5c42bc287 100644
 --- a/ansible/inventory/multinode
 +++ b/ansible/inventory/multinode
 @@ -29,6 +29,10 @@ monitoring01
@@ -140,20 +126,10 @@ index 3a3db6f29..8fa6a9889 100644
  
  [collectd:children]
  compute
-@@ -74,6 +80,7 @@ control
- monitoring
- network
- storage
-+vdiproxy
+@@ -603,3 +609,10 @@ letsencrypt
  
- [hacluster:children]
- control
-@@ -248,6 +255,16 @@ nova
- [nova-serialproxy:children]
- nova
- 
-+[kerbside-proxy:children]
-+nova
+ [letsencrypt-lego:children]
+ letsencrypt
 +
 +# Kerbside
 +[kerbside-api:children]
@@ -161,10 +137,6 @@ index 3a3db6f29..8fa6a9889 100644
 +
 +[kerbside-proxy:children]
 +vdiproxy
-+
- # Neutron
- [ironic-neutron-agent:children]
- neutron
 diff --git a/ansible/nova.yml b/ansible/nova.yml
 index 95eb6a141..196e456bd 100644
 --- a/ansible/nova.yml
@@ -377,12 +349,12 @@ index 367210639..104c9b858 100644
 +export KERBSIDE_API_URL='{{ kerbside_api_url }}'
 +{% endif %}
 diff --git a/ansible/roles/cron/tasks/config.yml b/ansible/roles/cron/tasks/config.yml
-index 83a95f9a6..3808f1c5b 100644
+index f45908c04..8324a3b78 100644
 --- a/ansible/roles/cron/tasks/config.yml
 +++ b/ansible/roles/cron/tasks/config.yml
-@@ -54,6 +54,7 @@
+@@ -53,6 +53,7 @@
+       - { name: "heat", enabled: "{{ enable_heat | bool }}" }
        - { name: "horizon", enabled: "{{ enable_horizon | bool }}" }
-       - { name: "influxdb", enabled: "{{ enable_influxdb | bool }}" }
        - { name: "ironic", enabled: "{{ enable_ironic | bool }}" }
 +      - { name: "kerbside", enabled: "{{ enable_kerbside | bool }}" }
        - { name: "keystone", enabled: "{{ enable_keystone | bool }}" }
@@ -1504,18 +1476,18 @@ index 2fe3b3e52..c62b51565 100644
  # OpenStack
  ####################
 diff --git a/ansible/site.yml b/ansible/site.yml
-index 9cec91e08..25c31500d 100644
+index 4167c041b..3b408af2f 100644
 --- a/ansible/site.yml
 +++ b/ansible/site.yml
-@@ -44,6 +44,7 @@
-         - enable_influxdb_{{ enable_influxdb | bool }}
+@@ -43,6 +43,7 @@
+         - enable_horizon_{{ enable_horizon | bool }}
          - enable_ironic_{{ enable_ironic | bool }}
          - enable_iscsid_{{ enable_iscsid | bool }}
 +        - enable_kerbside_{{ enable_kerbside | bool }}
          - enable_keystone_{{ enable_keystone | bool }}
          - enable_kuryr_{{ enable_kuryr | bool }}
          - enable_letsencrypt_{{ enable_letsencrypt | bool }}
-@@ -253,6 +254,12 @@
+@@ -245,6 +246,12 @@
              tasks_from: loadbalancer
            tags: keystone
            when: enable_keystone | bool
@@ -1543,20 +1515,6 @@ index 1120754a8..c42395908 100644
  kuryr_keystone_password:
  
  nova_database_password:
-diff --git a/tests/templates/inventory.j2 b/tests/templates/inventory.j2
-index b5bb76907..154633447 100644
---- a/tests/templates/inventory.j2
-+++ b/tests/templates/inventory.j2
-@@ -300,6 +300,9 @@ nova
- [nova-serialproxy:children]
- nova
- 
-+[kerbside:children]
-+nova
-+
- # Neutron
- [ironic-neutron-agent:children]
- neutron
 diff --git a/releasenotes/notes/deploy-kerbside-d7048c80e03cff33.yaml b/releasenotes/notes/deploy-kerbside-d7048c80e03cff33.yaml
 new file mode 100644
 index 000000000..b9e99e15a
@@ -1581,3 +1539,17 @@ index 000000000..b9e99e15a
 +    Kolla and Kolla-Ansible now support deploying Kerbside to provide access
 +    to spice-direct consoles. This functionality is enabled by setting
 +    ``enable_kerbside`` to ``true`` in globals.yml.
+diff --git a/tests/templates/inventory.j2 b/tests/templates/inventory.j2
+index 0751557a3..d194f3c99 100644
+--- a/tests/templates/inventory.j2
++++ b/tests/templates/inventory.j2
+@@ -296,6 +296,9 @@ nova
+ [nova-serialproxy:children]
+ nova
+ 
++[kerbside:children]
++nova
++
+ # Neutron
+ [ironic-neutron-agent:children]
+ neutron

--- a/_patches/patch144-use-customized-upper-constraints.patch
+++ b/_patches/patch144-use-customized-upper-constraints.patch
@@ -1,10 +1,11 @@
-commit a58909a147c0accea057e434cd34a8005fc93312
+commit f983220081fc74b5f08658a875277f853dc0f333
 Author: Michael Still <mikal@stillhq.com>
-Date:   Tue Feb 24 09:33:45 2026 +1100
+Date:   Sun Mar 15 09:44:23 2026 +1100
 
     Patch upper constraints.
     
     Change-Id: I5e106df95ff2a9735947c06c31d63c8786b4e404
+    Signed-off-by: Michael Still <mikal@stillhq.com>
 
 diff --git a/tox.ini b/tox.ini
 index 7e9beb8ef..16d59fe8e 100644

--- a/kolla-ansible-wave-1/config.yaml
+++ b/kolla-ansible-wave-1/config.yaml
@@ -5,7 +5,7 @@ shallow_clone: false
 directory: kolla-ansible
 release: master-wave-1
 depends_on: ''
-source_sha: 09ddc0d1b3ca1fc1c7e0de6e3bb49c4dc12581a8
-previous_source_sha: c740eadb0bc2baaacf237a00ecda1f6dd6e24aa0
+source_sha: d1be6167d224f89cc40dafec047bf06ea030a160
+previous_source_sha: 09ddc0d1b3ca1fc1c7e0de6e3bb49c4dc12581a8
 skip_rebase: true
 skip_claude: true

--- a/kolla-ansible/config.yaml
+++ b/kolla-ansible/config.yaml
@@ -5,5 +5,5 @@ shallow_clone: false
 directory: kolla-ansible
 release: master
 depends_on: requirements
-source_sha: 09ddc0d1b3ca1fc1c7e0de6e3bb49c4dc12581a8
-previous_source_sha: c740eadb0bc2baaacf237a00ecda1f6dd6e24aa0
+source_sha: d1be6167d224f89cc40dafec047bf06ea030a160
+previous_source_sha: 09ddc0d1b3ca1fc1c7e0de6e3bb49c4dc12581a8


### PR DESCRIPTION
Upstream removed influxdb from master without a release note in https://review.opendev.org/c/openstack/kolla-ansible/+/973050 . This required a manual rebase to resolve.

Fixes #970.