### PR TITLE
Add debsecan vulnerability scanning to build.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -339,6 +339,9 @@ jobs:
           if [ -e kerbside-patches/archive/occystrap-layer-cache.json ]; then
               cp kerbside-patches/archive/occystrap-layer-cache.json ${archive_path}/
           fi
+          if [ -d kerbside-patches/archive/debsecan ]; then
+              cp -r kerbside-patches/archive/debsecan ${archive_path}/
+          fi
 
           # System details for debugging
           docker info > ${archive_path}/docker-info.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ Build scripts live in `_build/`. Key files:
 - `imagebuild.sh` -- runs kolla-build (supports `--push`
   and `--registry` for proxy mode)
 - `imagearchive.sh` -- archives images with SBOMs
+- `debsecan-report.sh` -- scans built images for known
+  CVEs using debsecan (non-destructive, images unchanged)
 
 In CI, `--use-proxy` starts an occystrap filtering proxy
 on localhost:5050 before building. kolla-build pushes

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,6 +21,7 @@ kerbside-patches/
         build-containers.sh  # Build + push images via occystrap
         imagebuild.sh        # Run kolla-build
         imagearchive.sh      # Archive images with SBOMs
+        debsecan-report.sh   # Vulnerability scan with debsecan
         test-apply.sh        # Test patch application
         test-patches-for-ci.sh  # CI-friendly patch testing
         rebase-with-claude.sh   # Automated rebase with Claude
@@ -152,6 +153,30 @@ Data flow:
 3. CI uploads as build artifact
 4. `collect_layer_data` job aggregates across matrix builds
 5. Tarballs are committed to `data/` via automated PR
+
+### Security Vulnerability Scanning
+
+After images are built, `debsecan-report.sh` scans each
+image for known Debian/Ubuntu CVEs without modifying the
+images:
+
+```
+docker create image → docker cp dpkg/status → debsecan
+    |                                            |
+    v                                            v
+container removed              archive/debsecan/ reports
+(image unchanged)              (detail, simple, fixable, summary)
+```
+
+A temporary scanner image is built from the same base distro
+(`${distro}:${distro_version}`) so debsecan has the correct
+vulnerability data source. Non-Debian-derived images are
+detected via `/etc/os-release` and skipped.
+
+The scan produces both human-readable (`summary.txt`) and
+machine-parseable (`summary.json`) output. With
+`--debsecan-fail-on-fixable`, the build fails if any
+packages have available security fixes.
 
 ### Analysis
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,39 @@ pipeline stages within a single tarball.
 The workflow is configured to skip functional tests when only files in `data/`
 are changed, preventing infinite loops when layer data PRs are merged.
 
+# Security Vulnerability Scanning
+
+After container images are built, `debsecan` is run against each image to
+report known Debian/Ubuntu security vulnerabilities. The scan extracts the
+dpkg package database from each image and runs `debsecan` externally, so the
+scanned images are never modified and `debsecan` is not installed in the
+pushed container images.
+
+The scan supports both Debian and Ubuntu base images. Non-Debian-derived
+images are detected and skipped automatically.
+
+Reports are saved to `archive/debsecan/` and include:
+
+- Per-image detail reports (full CVE listing)
+- Per-image fixable CVE reports (packages with available fixes)
+- A combined summary (`summary.txt` and `summary.json`)
+
+The summary report is included as a CI build artifact.
+
+## Controlling the scan
+
+```bash
+# Skip the vulnerability scan entirely
+./buildall.sh --build-targets "master" --skip-debsecan
+
+# Fail the build if any fixable CVEs are found
+./buildall.sh --build-targets "master" --debsecan-fail-on-fixable
+
+# Run the scan standalone against already-built images
+./_build/debsecan-report.sh --build-targets "master" \
+    --distro debian --distro-version bookworm --image-tag local
+```
+
 # Script Reference
 
 This repository contains numerous helper scripts in the `_build/` and `tools/`
@@ -216,6 +249,7 @@ directories. This section documents each script and its purpose.
 | `build-containers.sh` | Builds Kolla container images using the patched source. Handles registry authentication and multi-release builds. Called by `buildall.sh`. |
 | `imagebuild.sh` | Core container image build logic. Prepares artifacts, runs `kolla-build`, and manages image tagging. |
 | `imagearchive.sh` | Archives built container images to `archive/imgs/` with SBOM generation. Exports patched source to `archive/src/`. |
+| `debsecan-report.sh` | Scans built container images for known security vulnerabilities using `debsecan`. Extracts the dpkg database from each image and scans externally -- the pushed images are never modified. Supports Debian and Ubuntu; skips non-Debian-derived images. Reports saved to `archive/debsecan/`. |
 | `common.sh` | Shared functions, command-line argument parsing, color output helpers, and default build configuration used by all other scripts. |
 
 ### Patch Testing Scripts

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -201,6 +201,39 @@ pipeline stages within a single tarball.
 The workflow is configured to skip functional tests when only files in `data/`
 are changed, preventing infinite loops when layer data PRs are merged.
 
+# Security Vulnerability Scanning
+
+After container images are built, `debsecan` is run against each image to
+report known Debian/Ubuntu security vulnerabilities. The scan extracts the
+dpkg package database from each image and runs `debsecan` externally, so the
+scanned images are never modified and `debsecan` is not installed in the
+pushed container images.
+
+The scan supports both Debian and Ubuntu base images. Non-Debian-derived
+images are detected and skipped automatically.
+
+Reports are saved to `archive/debsecan/` and include:
+
+- Per-image detail reports (full CVE listing)
+- Per-image fixable CVE reports (packages with available fixes)
+- A combined summary (`summary.txt` and `summary.json`)
+
+The summary report is included as a CI build artifact.
+
+## Controlling the scan
+
+```bash
+# Skip the vulnerability scan entirely
+./buildall.sh --build-targets "master" --skip-debsecan
+
+# Fail the build if any fixable CVEs are found
+./buildall.sh --build-targets "master" --debsecan-fail-on-fixable
+
+# Run the scan standalone against already-built images
+./_build/debsecan-report.sh --build-targets "master" \
+    --distro debian --distro-version bookworm --image-tag local
+```
+
 # Script Reference
 
 This repository contains numerous helper scripts in the `_build/` and `tools/`
@@ -216,6 +249,7 @@ directories. This section documents each script and its purpose.
 | `build-containers.sh` | Builds Kolla container images using the patched source. Handles registry authentication and multi-release builds. Called by `buildall.sh`. |
 | `imagebuild.sh` | Core container image build logic. Prepares artifacts, runs `kolla-build`, and manages image tagging. |
 | `imagearchive.sh` | Archives built container images to `archive/imgs/` with SBOM generation. Exports patched source to `archive/src/`. |
+| `debsecan-report.sh` | Scans built container images for known security vulnerabilities using `debsecan`. Extracts the dpkg database from each image and scans externally -- the pushed images are never modified. Supports Debian and Ubuntu; skips non-Debian-derived images. Reports saved to `archive/debsecan/`. |
 | `common.sh` | Shared functions, command-line argument parsing, color output helpers, and default build configuration used by all other scripts. |
 
 ### Patch Testing Scripts

--- a/_build/build-containers.sh
+++ b/_build/build-containers.sh
@@ -296,6 +296,34 @@ if [ "${proxy_running}" == "true" ]; then
     fi
 fi
 
+# Run debsecan vulnerability scan on the built images. This extracts the
+# dpkg database from each image and scans it externally, so the pushed
+# images are never modified.
+if [ "${skip_debsecan}" != "true" ]; then
+    debsecan_args=""
+    if [ "${debsecan_fail_on_fixable}" == "true" ]; then
+        debsecan_args="--debsecan-fail-on-fixable"
+    fi
+
+    # When --debsecan-fail-on-fixable is set, let the exit code propagate
+    # so the build fails. Otherwise, treat scan errors as non-fatal.
+    if [ "${debsecan_fail_on_fixable}" == "true" ]; then
+        ./_build/debsecan-report.sh \
+            --build-targets "${build_targets}" \
+            --distro "${distro}" \
+            --distro-version "${distro_version}" \
+            --image-tag "${image_tag}" \
+            ${debsecan_args}
+    else
+        ./_build/debsecan-report.sh \
+            --build-targets "${build_targets}" \
+            --distro "${distro}" \
+            --distro-version "${distro_version}" \
+            --image-tag "${image_tag}" \
+            ${debsecan_args} || true
+    fi
+fi
+
 echo
 trap - EXIT
 

--- a/_build/common.sh
+++ b/_build/common.sh
@@ -74,6 +74,12 @@ dont_fetch_images="false"
 # Should we use the occystrap filtering proxy for image pushes?
 use_proxy="false"
 
+# Should we skip the debsecan vulnerability scan?
+skip_debsecan="false"
+
+# Should we fail the build if fixable CVEs are found?
+debsecan_fail_on_fixable="false"
+
 # If we are building a cloud, what inventory should we use?
 topology="all-in-one"
 
@@ -210,6 +216,18 @@ while [[ ${found_arg} -gt 0 ]]; do
         --update-patches)
             export update_patches="true"
             echo "Will update patches to match what was applied."
+            shift
+            found_arg=1
+            ;;
+        --skip-debsecan)
+            export skip_debsecan="true"
+            echo "Will skip debsecan vulnerability scan."
+            shift
+            found_arg=1
+            ;;
+        --debsecan-fail-on-fixable)
+            export debsecan_fail_on_fixable="true"
+            echo "Will fail build if fixable CVEs are found."
             shift
             found_arg=1
             ;;

--- a/_build/debsecan-report.sh
+++ b/_build/debsecan-report.sh
@@ -56,7 +56,7 @@ for target in ${build_targets}; do
     fi
 
     for image in ${images}; do
-        safe_name=$(echo ${image} | tr '/' '-')
+        safe_name=$(echo ${image} | tr '/:' '-')
         echo
         echo -e "${H2}Scanning ${image}:${complete_image_tag}${Color_Off}"
 
@@ -182,7 +182,7 @@ done
 
     for i in $(seq 0 $((total_images - 1))); do
         image="${scanned_images[i]}"
-        safe_name=$(echo ${image%%:*} | tr '/' '-')
+        safe_name=$(echo ${image%%:*} | tr '/:' '-')
 
         echo "--- ${image} ---"
         echo "Total: ${scanned_cve_counts[i]}, Fixable: ${scanned_fixable_counts[i]}"

--- a/_build/debsecan-report.sh
+++ b/_build/debsecan-report.sh
@@ -16,7 +16,7 @@ echo -e "${H2}Building debsecan scanner image${Color_Off}"
 echo -e "${H3}Base: ${distro}:${distro_version}${Color_Off}"
 
 scanner_image="debsecan-scanner-${distro}-${distro_version}"
-if ! docker build -q -t ${scanner_image} -f - /dev/null <<DOCKERFILE
+if ! docker build -q -t ${scanner_image} - <<DOCKERFILE
 FROM ${distro}:${distro_version}
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \

--- a/_build/debsecan-report.sh
+++ b/_build/debsecan-report.sh
@@ -1,0 +1,246 @@
+#!/bin/bash -e
+
+# Run from the top directory.
+. _build/common.sh
+
+banner "Security vulnerability scan with debsecan"
+
+##############################################################################
+# Build a scanner image from the same base distro                            #
+##############################################################################
+
+# The scanner image uses the same base OS as the container images being
+# scanned. This ensures debsecan has the correct vulnerability data source
+# for the distro (Debian uses tracker.debian.org, Ubuntu uses its own).
+echo -e "${H2}Building debsecan scanner image${Color_Off}"
+echo -e "${H3}Base: ${distro}:${distro_version}${Color_Off}"
+
+scanner_image="debsecan-scanner-${distro}-${distro_version}"
+if ! docker build -q -t ${scanner_image} -f - /dev/null <<DOCKERFILE
+FROM ${distro}:${distro_version}
+RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+        --no-install-recommends debsecan ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+DOCKERFILE
+then
+    echo -e "${Red}Failed to build scanner image.${Color_Off}"
+    echo -e "${Red}debsecan scanning requires network access to install packages.${Color_Off}"
+    echo -e "${Red}Skipping vulnerability scan.${Color_Off}"
+    trap - EXIT
+    exit 0
+fi
+
+##############################################################################
+# Scan each built image                                                      #
+##############################################################################
+
+debsecan_dir="${topdir}/archive/debsecan"
+mkdir -p "${debsecan_dir}"
+
+# Accumulate per-image results for the summary
+declare -a scanned_images
+declare -a scanned_cve_counts
+declare -a scanned_fixable_counts
+
+for target in ${build_targets}; do
+    complete_image_tag="${target}-${distro}-${distro_version}-${image_tag}"
+
+    images=$(docker image list --format json | \
+        jq --slurp -r \
+        ".[] | select(.Tag == \"${complete_image_tag}\") | .Repository")
+
+    if [ -z "${images}" ]; then
+        echo -e "${H3}No local images found for tag ${complete_image_tag}, skipping${Color_Off}"
+        continue
+    fi
+
+    for image in ${images}; do
+        safe_name=$(echo ${image} | tr '/' '-')
+        echo
+        echo -e "${H2}Scanning ${image}:${complete_image_tag}${Color_Off}"
+
+        # Create a temporary container to extract the dpkg database and
+        # os-release. The container is never started -- we just need the
+        # filesystem.
+        workdir=$(mktemp -d)
+
+        cid=$(docker create "${image}:${complete_image_tag}" true)
+
+        if ! docker cp "${cid}:/var/lib/dpkg/status" "${workdir}/status" \
+            2>/dev/null
+        then
+            echo -e "${H3}No dpkg database found -- not Debian-derived, skipping${Color_Off}"
+            docker rm "${cid}" > /dev/null
+            rm -rf "${workdir}"
+            continue
+        fi
+
+        if ! docker cp "${cid}:/etc/os-release" "${workdir}/os-release" \
+            2>/dev/null
+        then
+            echo -e "${H3}No os-release found, skipping${Color_Off}"
+            docker rm "${cid}" > /dev/null
+            rm -rf "${workdir}"
+            continue
+        fi
+
+        docker rm "${cid}" > /dev/null
+
+        # Determine the suite and verify this is Debian-derived
+        suite=$(grep "^VERSION_CODENAME=" "${workdir}/os-release" \
+            | cut -d= -f2)
+        distro_id=$(grep "^ID=" "${workdir}/os-release" | cut -d= -f2)
+        id_like=$(grep "^ID_LIKE=" "${workdir}/os-release" \
+            | cut -d= -f2 || true)
+
+        if [ -z "${suite}" ]; then
+            echo -e "${H3}Could not determine suite, skipping${Color_Off}"
+            rm -rf "${workdir}"
+            continue
+        fi
+
+        if [ "${distro_id}" != "debian" ] \
+            && [ "${distro_id}" != "ubuntu" ] \
+            && [[ "${id_like}" != *"debian"* ]]
+        then
+            echo -e "${H3}Not Debian-derived (ID=${distro_id}), skipping${Color_Off}"
+            rm -rf "${workdir}"
+            continue
+        fi
+
+        echo -e "${H3}Distro: ${distro_id}, Suite: ${suite}${Color_Off}"
+
+        # Full detail report (human-readable)
+        docker run --rm \
+            -v "${workdir}/status:/scan/status:ro" \
+            ${scanner_image} \
+            debsecan --suite "${suite}" --status /scan/status \
+                --format detail \
+            > "${debsecan_dir}/${safe_name}-detail.txt" 2>&1 || true
+
+        # Simple one-line-per-CVE report (for counting / parsing)
+        docker run --rm \
+            -v "${workdir}/status:/scan/status:ro" \
+            ${scanner_image} \
+            debsecan --suite "${suite}" --status /scan/status \
+                --format simple \
+            > "${debsecan_dir}/${safe_name}-simple.txt" 2>&1 || true
+
+        # Fixable CVEs only (packages where a fix is available in the suite)
+        docker run --rm \
+            -v "${workdir}/status:/scan/status:ro" \
+            ${scanner_image} \
+            debsecan --suite "${suite}" --status /scan/status \
+                --only-fixed --format simple \
+            > "${debsecan_dir}/${safe_name}-fixable.txt" 2>&1 || true
+
+        image_cves=$(wc -l < "${debsecan_dir}/${safe_name}-simple.txt")
+        image_fixable=$(wc -l < "${debsecan_dir}/${safe_name}-fixable.txt")
+
+        echo -e "${H3}Total CVEs: ${image_cves}${Color_Off}"
+        echo -e "${H3}Fixable CVEs: ${image_fixable}${Color_Off}"
+
+        scanned_images+=("${image}:${complete_image_tag}")
+        scanned_cve_counts+=(${image_cves})
+        scanned_fixable_counts+=(${image_fixable})
+
+        rm -rf "${workdir}"
+    done
+done
+
+##############################################################################
+# Generate summary report                                                    #
+##############################################################################
+
+total_images=${#scanned_images[@]}
+total_cves=0
+total_fixable=0
+
+for i in $(seq 0 $((total_images - 1))); do
+    total_cves=$((total_cves + scanned_cve_counts[i]))
+    total_fixable=$((total_fixable + scanned_fixable_counts[i]))
+done
+
+{
+    echo "debsecan Vulnerability Report"
+    echo "============================="
+    echo ""
+    echo "Generated: $(date -Iseconds)"
+    echo "Base distro: ${distro} ${distro_version}"
+    echo "Images scanned: ${total_images}"
+    echo "Total CVEs (all images): ${total_cves}"
+    echo "Fixable CVEs (all images): ${total_fixable}"
+    echo ""
+
+    for i in $(seq 0 $((total_images - 1))); do
+        image="${scanned_images[i]}"
+        safe_name=$(echo ${image%%:*} | tr '/' '-')
+
+        echo "--- ${image} ---"
+        echo "Total: ${scanned_cve_counts[i]}, Fixable: ${scanned_fixable_counts[i]}"
+
+        fixable_file="${debsecan_dir}/${safe_name}-fixable.txt"
+        if [ -s "${fixable_file}" ]; then
+            echo ""
+            echo "Fixable CVEs:"
+            cat "${fixable_file}"
+        fi
+        echo ""
+    done
+} > "${debsecan_dir}/summary.txt"
+
+# Also generate a JSON summary for machine consumption
+{
+    echo "{"
+    echo "  \"generated\": \"$(date -Iseconds)\","
+    echo "  \"distro\": \"${distro}\","
+    echo "  \"distro_version\": \"${distro_version}\","
+    echo "  \"total_images\": ${total_images},"
+    echo "  \"total_cves\": ${total_cves},"
+    echo "  \"total_fixable\": ${total_fixable},"
+    echo "  \"images\": ["
+
+    for i in $(seq 0 $((total_images - 1))); do
+        image="${scanned_images[i]}"
+        comma=""
+        if [ $i -lt $((total_images - 1)) ]; then
+            comma=","
+        fi
+        echo "    {"
+        echo "      \"image\": \"${image}\","
+        echo "      \"total_cves\": ${scanned_cve_counts[i]},"
+        echo "      \"fixable_cves\": ${scanned_fixable_counts[i]}"
+        echo "    }${comma}"
+    done
+
+    echo "  ]"
+    echo "}"
+} > "${debsecan_dir}/summary.json"
+
+##############################################################################
+# Report results                                                             #
+##############################################################################
+
+echo
+echo -e "${H2}debsecan Summary${Color_Off}"
+echo -e "${H3}Images scanned: ${total_images}${Color_Off}"
+echo -e "${H3}Total CVEs: ${total_cves}${Color_Off}"
+echo -e "${H3}Fixable CVEs: ${total_fixable}${Color_Off}"
+echo -e "${H3}Reports: ${debsecan_dir}/${Color_Off}"
+
+# Clean up the scanner image
+docker rmi ${scanner_image} > /dev/null 2>&1 || true
+
+if [ "${debsecan_fail_on_fixable}" == "true" ] \
+    && [ ${total_fixable} -gt 0 ]
+then
+    echo
+    echo -e "${Red}BUILD FAILURE: ${total_fixable} fixable CVEs found.${Color_Off}"
+    echo -e "${Red}Run with --skip-debsecan to bypass, or update packages.${Color_Off}"
+    exit 1
+fi
+
+trap - EXIT
+
+banner "Security vulnerability scan complete."

--- a/_build/debsecan-report.sh
+++ b/_build/debsecan-report.sh
@@ -76,13 +76,20 @@ for target in ${build_targets}; do
             continue
         fi
 
-        if ! docker cp "${cid}:/etc/os-release" "${workdir}/os-release" \
+        # /etc/os-release is a symlink to /usr/lib/os-release on Debian
+        # and docker cp on a non-running container may not follow symlinks.
+        # Try the canonical path first, then fall back to the symlink.
+        if ! docker cp "${cid}:/usr/lib/os-release" "${workdir}/os-release" \
             2>/dev/null
         then
-            echo -e "${H3}No os-release found, skipping${Color_Off}"
-            docker rm "${cid}" > /dev/null
-            rm -rf "${workdir}"
-            continue
+            if ! docker cp "${cid}:/etc/os-release" "${workdir}/os-release" \
+                2>/dev/null
+            then
+                echo -e "${H3}No os-release found, skipping${Color_Off}"
+                docker rm "${cid}" > /dev/null
+                rm -rf "${workdir}"
+                continue
+            fi
         fi
 
         docker rm "${cid}" > /dev/null


### PR DESCRIPTION
Add a post-build debsecan vulnerability scan that reports known Debian/Ubuntu CVEs without modifying the pushed container images. The scan extracts the dpkg database from each built image via docker create/cp and runs debsecan externally against it.

A temporary scanner image is built from the same base distro so debsecan has the correct vulnerability data. Non-Debian-derived images are detected and skipped.

New CLI flags: --skip-debsecan to bypass the scan, and --debsecan-fail-on-fixable to fail the build when
packages have available security fixes.

Reports (per-image detail, fixable CVEs, and a combined summary in text and JSON) are saved to archive/debsecan/ and collected as CI artifacts.

Prompt: Add a run of debsecan and a summary report to the kolla-build container build process without installing debsecan in the pushed container images. Support both Debian and Ubuntu, skip non-Debian-derived images. Make the summary report a CI artifact. Add an opt-in flag to fail the build on fixable CVEs.


Assisted-By: Claude Code