### PR TITLE
Fix missing /var/log/kolla after upstream logging refactor.

### DIFF
--- a/_patches/patch147-kolla-ansible-master-kolla-ansible-kerbside-role.patch
+++ b/_patches/patch147-kolla-ansible-master-kolla-ansible-kerbside-role.patch
@@ -126,7 +126,15 @@ index 4aaec0785..e05532d01 100644
  
  [collectd:children]
  compute
-@@ -606,3 +612,10 @@ letsencrypt
+@@ -202,6 +208,7 @@
+ compute
+ storage
+ monitoring
++vdiproxy
+ 
+ [opensearch:children]
+ control
+@@ -606,3 +613,10 @@ letsencrypt
  
  [letsencrypt-lego:children]
  letsencrypt

--- a/etc/inventory-all-in-one-master
+++ b/etc/inventory-all-in-one-master
@@ -191,7 +191,7 @@ common
 [fluentd:children]
 common
 
-[kolla-logs:children]
+[kolla_logs:children]
 common
 
 [kolla-toolbox:children]

--- a/etc/inventory-multinode-2-master
+++ b/etc/inventory-multinode-2-master
@@ -213,7 +213,7 @@ common
 [fluentd:children]
 common
 
-[kolla-logs:children]
+[kolla_logs:children]
 common
 
 [kolla-toolbox:children]

--- a/etc/inventory-multinode-master
+++ b/etc/inventory-multinode-master
@@ -213,7 +213,7 @@ common
 [fluentd:children]
 common
 
-[kolla-logs:children]
+[kolla_logs:children]
 common
 
 [kolla-toolbox:children]


### PR DESCRIPTION
Kolla-ansible commit 894fcd5aa extracted log volume setup from the common role into a new logs role, and renamed the inventory group from kolla-logs to kolla_logs. Update the CI inventories to use the new group name, and add vdiproxy to the kolla_logs group in the upstream multinode inventory patch since that group now explicitly lists children.

Prompt: Debug missing /var/log/kolla in CI debug bundles after daily rebase picked up kolla-ansible commit 894fcd5aa which refactored logging into a separate role with a renamed inventory group.



Assisted-By: Claude Code