### PR TITLE
Remove duplicate broken kerbside inventory block in patch156.

### DIFF
--- a/_patches/patch156-tempest-tests.patch
+++ b/_patches/patch156-tempest-tests.patch
@@ -112,20 +112,7 @@ index e2c5ff338..5786529fc 100644
  
  [collectd:children]
  compute
-@@ -319,6 +326,12 @@ nova
- [nova-serialproxy:children]
- nova
- 
-+[kerbside_api:children]
-+kerbside
-+
-+[kerbside_proxy:children]
-+kerbside
-+
- # Neutron
- [ironic-neutron-agent:children]
- neutron
-@@ -708,3 +721,10 @@ skyline
+@@ -708,3 +715,10 @@ skyline
  
  [skyline-console:children]
  skyline


### PR DESCRIPTION
patch156-tempest-tests.patch was adding two [kerbside_*:children] blocks to tests/templates/inventory.j2: a broken duplicate at @@ -319 +326 @@ that referenced an undefined "kerbside" group, plus the correct block at the end that references control and vdiproxy.

The bad block caused the kolla-ansible-debian-trixie-kerbside Zuul job (e.g. build af513e06235d4b85aa0ebc4e23a1b20e on Gerrit change 988189 patchset 6) to fail at setup_gate.sh with:

  Failed to parse inventory: Section [kerbside_proxy:children]
  includes undefined group 'kerbside'.

Earlier commit 781fad1e33 ("We don't need the kerbside group") only refreshed the patch's commit metadata and d6aa72be2a only fixed the etc/inventory-* templates used by local builds; neither touched the upstream-facing tests/templates/inventory.j2 hunk in patch156.

Drop the broken hunk and adjust the offset of the next hunk from +721,10 to +715,10. Verified with
"./_build/test-apply.sh --skip-tests --test-patch patch156 kolla-ansible" and confirmed the resulting inventory.j2 retains only the correct kerbside block.

Prompt: Debug the failing kolla-ansible-debian-trixie-kerbside Zuul job linked at zuul.opendev.org/t/openstack/build/af513e06235d4b85aa0ebc4e23a1b20e and fix it. After tracing the inventory parse error to a duplicate broken hunk inside patch156-tempest-tests.patch, the user asked me to commit the fix.


Assisted-By: Claude Opus 4.7 (1M context, low effort)