### PR TITLE
Disable nova_spice_html5 in kerbside CI scenario.

### DIFF
--- a/_patches/patch121-kolla-ansible-master-support-secure-spice.patch
+++ b/_patches/patch121-kolla-ansible-master-support-secure-spice.patch
@@ -17,22 +17,15 @@ Date:   Wed May 13 12:00:32 2026 +1000
     Change-Id: I4306725fb8433860baec8e01c51e9eae2beb3cc9
     Signed-off-by: Michael Still <mikal@stillhq.com>
 
-diff --git a/ansible/roles/nova-cell/defaults/main.yml b/ansible/roles/nova-cell/defaults/main.yml
-index 790190fb0..b82dde11c 100644
---- a/ansible/roles/nova-cell/defaults/main.yml
-+++ b/ansible/roles/nova-cell/defaults/main.yml
-@@ -688,6 +688,11 @@ nova_cell_database_enable_tls_internal: "{{ database_enable_tls_internal | bool
- 
- nova_multi_compute_ironic_config: []
- 
-+##################
-+# Spice options
-+##################
+diff --git a/ansible/group_vars/all/nova.yml b/ansible/group_vars/all/nova.yml
+index 4b116200a..b9a8d6a7c 100644
+--- a/ansible/group_vars/all/nova.yml
++++ b/ansible/group_vars/all/nova.yml
+@@ -74,3 +74,4 @@ nova_spice_jpeg_compression: "auto"
+ nova_spice_zlib_compression: "auto"
+ nova_spice_playback_compression: true
+ nova_spice_streaming_mode: "filter"
 +nova_spice_require_secure: false
-+
- ###################
- # Copy certificates
- ###################
 diff --git a/ansible/roles/nova-cell/tasks/precheck.yml b/ansible/roles/nova-cell/tasks/precheck.yml
 index 9364c619e..b61d2292c 100644
 --- a/ansible/roles/nova-cell/tasks/precheck.yml

--- a/_patches/patch156-tempest-tests.patch
+++ b/_patches/patch156-tempest-tests.patch
@@ -68,13 +68,14 @@ diff --git a/tests/templates/globals-default.j2 b/tests/templates/globals-defaul
 index 0f6da316a..0956aeb18 100644
 --- a/tests/templates/globals-default.j2
 +++ b/tests/templates/globals-default.j2
-@@ -118,6 +118,11 @@ enable_masakari: "yes"
+@@ -118,6 +118,12 @@ enable_masakari: "yes"
  enable_valkey: "yes"
  {% endif %}
  
 +{% if scenario == "kerbside" %}
 +enable_kerbside: "yes"
 +nova_console: "spice"
++nova_spice_html5: "no"
 +{% endif %}
 +
  {% if scenario == "cells" %}

--- a/globals.yml
+++ b/globals.yml
@@ -587,11 +587,7 @@ enable_haproxy: "no"
 # Valid options are [ none, novnc, spice ]
 nova_console: "spice"
 nova_spice_html5: "no"
-nova_spice_require_secure: "no"
-nova_spice_debug_logging: "no"
-nova_spice_allow_concurrent: "yes"
 enable_kerbside: "yes"
-kerbside_json_logging: "no"
 
 ##############################
 # Neutron - networking options


### PR DESCRIPTION
The kolla-ansible-rocky-10-kerbside Zuul job (e.g. build 9116fc16f2204b3ea434e94140845e2e) failed during "Run kolla-ansible pull" with a 404 trying to fetch
lokolla/nova-spicehtml5proxy:change_988189 from the local registry.

Kolla does not build nova-spicehtml5proxy on Rocky 10 because RHEL9 and Rocky removed SPICE from qemu, but kolla-ansible's nova-cell defaults enable that container whenever:

    nova_console == 'spice' and (nova_spice_html5 | bool)

patch156 set nova_console: "spice" in the kerbside scenario block of globals-default.j2 and left nova_spice_html5 at its default of true, so the spice HTML5 transcoding proxy got enabled even though kerbside provides spice-direct and the HTML5 proxy is not needed for that path.

Add nova_spice_html5: "no" to the kerbside scenario block so the nova-spicehtml5proxy container is disabled. This avoids the missing image on Rocky 10 and removes a redundant moving part from the other distro variants too.

Prompt: Debug the kolla-ansible-rocky-10-kerbside Zuul failure at zuul.opendev.org/t/openstack/build/9116fc16f2204b3ea434e94140845e2e and fix it. After tracing the 404 on nova-spicehtml5proxy to the combination of nova_console=spice plus the default nova_spice_html5 in the kerbside scenario, the user asked me to commit the fix.


Assisted-By: Claude Opus 4.7 (1M context, low effort)