### PR TITLE
Add stub task files for missing kolla_actions in kerbside role.

### DIFF
--- a/_patches/patch147-kolla-ansible-master-kolla-ansible-kerbside-role.patch
+++ b/_patches/patch147-kolla-ansible-master-kolla-ansible-kerbside-role.patch
@@ -874,6 +874,20 @@ index 000000000..df1363afa
 +  when:
 +    - service | service_enabled_and_mapped_to_host
 +    - kerbside_wsgi_provider == "uwsgi"
+diff --git a/ansible/roles/kerbside/tasks/check.yml b/ansible/roles/kerbside/tasks/check.yml
+new file mode 100644
+index 000000000..e69de29bb
+--- /dev/null
++++ b/ansible/roles/kerbside/tasks/check.yml
+@@ -0,0 +1 @@
++---
+diff --git a/ansible/roles/kerbside/tasks/config_validate.yml b/ansible/roles/kerbside/tasks/config_validate.yml
+new file mode 100644
+index 000000000..e69de29bb
+--- /dev/null
++++ b/ansible/roles/kerbside/tasks/config_validate.yml
+@@ -0,0 +1 @@
++---
 diff --git a/ansible/roles/kerbside/tasks/copy-certs.yml b/ansible/roles/kerbside/tasks/copy-certs.yml
 new file mode 100644
 index 000000000..3813d420b
@@ -904,6 +918,13 @@ index 000000000..3813d420b
 +    (inventory_hostname is in groups['kerbside_api'] or
 +     inventory_hostname is in groups['kerbside_proxy'])
 +  with_dict: "{{ kerbside_services | select_services_enabled_and_mapped_to_host }}"
+diff --git a/ansible/roles/kerbside/tasks/deploy-containers.yml b/ansible/roles/kerbside/tasks/deploy-containers.yml
+new file mode 100644
+index 000000000..e69de29bb
+--- /dev/null
++++ b/ansible/roles/kerbside/tasks/deploy-containers.yml
+@@ -0,0 +1 @@
++---
 diff --git a/ansible/roles/kerbside/tasks/deploy.yml b/ansible/roles/kerbside/tasks/deploy.yml
 new file mode 100644
 index 000000000..f47601806
@@ -920,6 +941,13 @@ index 000000000..f47601806
 +
 +- name: Flush handlers
 +  ansible.builtin.meta: flush_handlers
+diff --git a/ansible/roles/kerbside/tasks/destroy.yml b/ansible/roles/kerbside/tasks/destroy.yml
+new file mode 100644
+index 000000000..e69de29bb
+--- /dev/null
++++ b/ansible/roles/kerbside/tasks/destroy.yml
+@@ -0,0 +1 @@
++---
 diff --git a/ansible/roles/kerbside/tasks/loadbalancer.yml b/ansible/roles/kerbside/tasks/loadbalancer.yml
 new file mode 100644
 index 000000000..c060efa26
@@ -1090,6 +1118,13 @@ index 000000000..cf5adbf32
 +- name: Pull kerbside container images
 +  ansible.builtin.import_role:
 +    role: service-images-pull
+diff --git a/ansible/roles/kerbside/tasks/reconfigure.yml b/ansible/roles/kerbside/tasks/reconfigure.yml
+new file mode 100644
+index 000000000..e69de29bb
+--- /dev/null
++++ b/ansible/roles/kerbside/tasks/reconfigure.yml
+@@ -0,0 +1 @@
++---
 diff --git a/ansible/roles/kerbside/tasks/reload.yml b/ansible/roles/kerbside/tasks/reload.yml
 new file mode 100644
 index 000000000..ae846b944
@@ -1119,6 +1154,13 @@ index 000000000..ae846b944
 +  with_items:
 +    - kerbside_api
 +    - kerbside_proxy
+diff --git a/ansible/roles/kerbside/tasks/stop.yml b/ansible/roles/kerbside/tasks/stop.yml
+new file mode 100644
+index 000000000..e69de29bb
+--- /dev/null
++++ b/ansible/roles/kerbside/tasks/stop.yml
+@@ -0,0 +1 @@
++---
 diff --git a/ansible/roles/kerbside/tasks/upgrade.yml b/ansible/roles/kerbside/tasks/upgrade.yml
 new file mode 100644
 index 000000000..a84390a5b


### PR DESCRIPTION
The kerbside role's tasks/main.yml unconditionally includes "{{ kolla_action }}.yml", which means every kolla-ansible subcommand (deploy, validate-config, reconfigure, stop, destroy, check, deploy-containers, ...) looks for a matching file in the role. Until now only six of those existed (bootstrap, config, deploy, precheck, pull, upgrade plus their helpers), so any other subcommand crashed with "Could not find or access config_validate.yml" — which is what just broke the kolla-ansible-debian-trixie-kerbside Zuul job.

Add empty stub files for the six missing actions: config_validate, check, deploy-containers, destroy, reconfigure, stop. config_validate is intentionally empty: kerbside is not an OpenStack service and ships no oslo-config-generator, so there is nothing to validate (the upstream cron role does the same). The other five are placeholders that need real implementations — follow-up issues track each one. Without the stubs the Zuul job fails before any real validation can run.

Prompt: Investigate a Zuul failure on the kolla-ansible-debian-trixie-kerbside job which reported a fatal "Could not find or access config_validate.yml" when the validate-config subcommand was invoked. Trace the gap to the kerbside role's task files, audit what other kolla_action subcommands lack a corresponding file, and ship stubs to unblock CI while leaving real implementations to follow-up work.


Assisted-By: Claude Opus 4.7 (1M context, medium effort)