### PR TITLE
Register 15-kerbside.conf.j2 with fluentd.

### DIFF
--- a/_patches/patch147-kolla-ansible-master-kolla-ansible-kerbside-role.patch
+++ b/_patches/patch147-kolla-ansible-master-kolla-ansible-kerbside-role.patch
@@ -362,6 +362,19 @@ index e21b24458..c64ba1781 100644
    - name: keystone
      enabled: "{{ enable_keystone | bool }}"
    - name: magnum
+diff --git a/ansible/roles/fluentd/tasks/config.yml b/ansible/roles/fluentd/tasks/config.yml
+index d6c8cb649..f1b1b1b1b 100644
+--- a/ansible/roles/fluentd/tasks/config.yml
++++ b/ansible/roles/fluentd/tasks/config.yml
+@@ -101,6 +101,8 @@
+         enabled: true
+       - name: "conf/input/14-valkey.conf.j2"
+         enabled: "{{ enable_valkey | bool }}"
++      - name: "conf/input/15-kerbside.conf.j2"
++        enabled: "{{ enable_kerbside | bool }}"
+     customised_input_files: "{{ find_custom_fluentd_inputs.files | map(attribute='path') | list }}"
+     # Filters
+     fluentd_filter_files: "{{ default_filter_files | customise_fluentd(customised_filter_files) }}"
 diff --git a/ansible/roles/fluentd/templates/conf/filter/01-rewrite.conf.j2 b/ansible/roles/fluentd/templates/conf/filter/01-rewrite.conf.j2
 index 02f960700..4264e5fcd 100644
 --- a/ansible/roles/fluentd/templates/conf/filter/01-rewrite.conf.j2


### PR DESCRIPTION
The previous commit added a kerbside-specific fluentd input template at ansible/roles/fluentd/templates/conf/input/15-kerbside.conf.j2, but did not add it to default_input_files in
ansible/roles/fluentd/tasks/config.yml. fluentd.conf.j2 iterates over fluentd_input_files (derived from default_input_files), so the new template was never rendered into the final fluentd.conf. The result was that the kerbside source block was missing entirely: kerbside_api.log and kerbside_proxy.log were excluded from the global tail (correctly) but had nothing else picking them up. tests/check-logs.sh then failed with "no match for /var/log/kolla/kerbside/kerbside_api.log" (and proxy.log) because it never saw "following tail of ..." for those paths in fluentd.log.

Add the entry, gated on enable_kerbside, so the template is rendered when kerbside is deployed.

Confirmed by running _build/test-apply.sh against kolla-ansible and checking that the assembled tree's tasks/config.yml now lists 15-kerbside.conf.j2 alongside the other input templates.

Prompt: Mikal pointed me at a follow-up Zuul failure (da557f11d0dd47a591acfee89f76cd58) for kolla-ansible 988189/12, where check-logs.sh complained that fluentd never tailed kerbside_api.log or kerbside_proxy.log. After tracing the rendered fluentd.conf and confirming the kerbside source block was missing, I identified the unregistered template as the root cause and amended patch147 to register it.


Assisted-By: Claude Opus 4.7 (1M context, medium effort) <noreply@anthropic.com>