### PR TITLE
Add patch157: spice-direct tempest test in kerbside scenario.

### DIFF
--- a/_patches/patch157-kerbside-tempest-spice-direct.patch
+++ b/_patches/patch157-kerbside-tempest-spice-direct.patch
@@ -1,0 +1,90 @@
+commit 5f0a3b4c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f60
+Author: Michael Still <mikal@stillhq.com>
+Date:   Mon May 18 10:00:00 2026 +1000
+
+    Run the spice-direct tempest test in the kerbside scenario.
+
+    The kerbside scenario jobs added in I1784562d already deploy
+    kolla-ansible with enable_kerbside=yes and nova_console=spice, then
+    run the default ".*smoke.*" Tempest regex. This adds the SPICE
+    coverage that motivated the scenario in the first place.
+
+    The test itself lives in upstream Tempest as
+    tempest.api.compute.admin.test_spice.SpiceDirectConsoleTestJSON
+    and exercises the full spice-direct console flow: create an
+    instance, request a console token, exchange it for hypervisor
+    connection details, and complete a SPICE protocol handshake
+    against the returned hypervisor host:port. It skips itself unless
+    CONF.compute_feature_enabled.spice_console is True, and nothing
+    in kolla-ansible currently sets that — python-tempestconf does
+    not auto-detect SPICE from the cloud.
+
+    Two changes are needed:
+
+    1. roles/kolla-ansible-tempest gains a new
+       kolla_ansible_tempest_discover_overrides list, whose entries
+       are appended as positional "section.option value" arguments to
+       discover-tempest-config. This is the same override syntax the
+       role already uses for compute.build_timeout, so no new code
+       path is introduced — just a per-scenario knob.
+
+    2. zuul.d/scenarios/kerbside.yaml sets that override to enable
+       compute-feature-enabled.spice_console and extends
+       kolla_ansible_tempest_regex so the spice test is selected
+       alongside the existing smoke tests. The test has no smoke
+       decorator, so without this it would be discovered but not
+       run.
+
+    Note that this test _does_not_ validate that Kerbside is deployed
+    and working correctly. That's the next step after this one.
+
+    Prompt: Michael asked for a follow-up patch to patch156 that
+    actually runs the spice-direct Tempest test (originally added to
+    Tempest for Nova's CI) inside the kerbside scenario.
+
+    Assisted-By: Claude Opus 4.7 (1M context, medium effort) <noreply@anthropic.com>
+    Co-Authored-By: Claude Opus 4.7 (1M context, medium effort) <noreply@anthropic.com>
+
+    Change-Id: I2c8d1e0a3f4b5d6c7e8f9a0b1c2d3e4f5a6b7c8d
+    Signed-off-by: Michael Still <mikal@stillhq.com>
+
+diff --git a/roles/kolla-ansible-tempest/defaults/main.yml b/roles/kolla-ansible-tempest/defaults/main.yml
+index 1a2b3c4..2b3c4d5 100644
+--- a/roles/kolla-ansible-tempest/defaults/main.yml
++++ b/roles/kolla-ansible-tempest/defaults/main.yml
+@@ -5,6 +5,7 @@ kolla_ansible_tempest_packages:
+
+ kolla_ansible_tempest_build_timeout: 900
+ kolla_ansible_tempest_cirros_ver: "0.6.3"
++kolla_ansible_tempest_discover_overrides: []
+ kolla_ansible_tempest_exclude_regex: []
+ kolla_ansible_tempest_packages_extra: []
+ kolla_ansible_tempest_regex: []
+diff --git a/roles/kolla-ansible-tempest/tasks/main.yml b/roles/kolla-ansible-tempest/tasks/main.yml
+index 3c4d5e6..4d5e6f7 100644
+--- a/roles/kolla-ansible-tempest/tasks/main.yml
++++ b/roles/kolla-ansible-tempest/tasks/main.yml
+@@ -28,6 +28,7 @@
+       --image {{ image }}
+       --os-cloud kolla-admin
+       compute.build_timeout {{ kolla_ansible_tempest_build_timeout }}
++      {{ kolla_ansible_tempest_discover_overrides | join(' ') }}
+       >/tmp/logs/ansible/test-init-tempest-discover 2>&1
+   changed_when: false
+
+diff --git a/zuul.d/scenarios/kerbside.yaml b/zuul.d/scenarios/kerbside.yaml
+index 554c340..6e5f4a3 100644
+--- a/zuul.d/scenarios/kerbside.yaml
++++ b/zuul.d/scenarios/kerbside.yaml
+@@ -12,6 +12,11 @@
+     vars:
+       scenario: kerbside
+       kolla_build_images: true
++      kolla_ansible_tempest_regex:
++        - .*smoke.*
++        - tempest\.api\.compute\.admin\.test_spice
++      kolla_ansible_tempest_discover_overrides:
++        - "compute-feature-enabled.spice_console True"
+       scenario_images_extra:
+         - ^kerbside
+         - ^nova-libvirt-spice

--- a/_patches/patch157-kerbside-tempest-spice-direct.patch-message
+++ b/_patches/patch157-kerbside-tempest-spice-direct.patch-message
@@ -1,0 +1,45 @@
+Run the spice-direct tempest test in the kerbside scenario.
+
+The kerbside scenario jobs added in I1784562d already deploy
+kolla-ansible with enable_kerbside=yes and nova_console=spice, then
+run the default ".*smoke.*" Tempest regex. This adds the SPICE
+coverage that motivated the scenario in the first place.
+
+The test itself lives in upstream Tempest as
+tempest.api.compute.admin.test_spice.SpiceDirectConsoleTestJSON
+and exercises the full spice-direct console flow: create an
+instance, request a console token, exchange it for hypervisor
+connection details, and complete a SPICE protocol handshake
+against the returned hypervisor host:port. It skips itself unless
+CONF.compute_feature_enabled.spice_console is True, and nothing
+in kolla-ansible currently sets that — python-tempestconf does
+not auto-detect SPICE from the cloud.
+
+Two changes are needed:
+
+1. roles/kolla-ansible-tempest gains a new
+   kolla_ansible_tempest_discover_overrides list, whose entries
+   are appended as positional "section.option value" arguments to
+   discover-tempest-config. This is the same override syntax the
+   role already uses for compute.build_timeout, so no new code
+   path is introduced — just a per-scenario knob.
+
+2. zuul.d/scenarios/kerbside.yaml sets that override to enable
+   compute-feature-enabled.spice_console and extends
+   kolla_ansible_tempest_regex so the spice test is selected
+   alongside the existing smoke tests. The test has no smoke
+   decorator, so without this it would be discovered but not
+   run.
+
+Note that this test _does_not_ validate that Kerbside is deployed
+and working correctly. That's the next step after this one.
+
+Prompt: Michael asked for a follow-up patch to patch156 that
+actually runs the spice-direct Tempest test (originally added to
+Tempest for Nova's CI) inside the kerbside scenario.
+
+Assisted-By: Claude Opus 4.7 (1M context, medium effort) <noreply@anthropic.com>
+Co-Authored-By: Claude Opus 4.7 (1M context, medium effort) <noreply@anthropic.com>
+
+Change-Id: I2c8d1e0a3f4b5d6c7e8f9a0b1c2d3e4f5a6b7c8d
+Signed-off-by: Michael Still <mikal@stillhq.com>

--- a/kolla-ansible-wave-1/ORDER
+++ b/kolla-ansible-wave-1/ORDER
@@ -1,3 +1,4 @@
 ../_patches/patch121-kolla-ansible-master-support-secure-spice.patch
 ../_patches/patch147-kolla-ansible-master-kolla-ansible-kerbside-role.patch
 ../_patches/patch156-tempest-tests.patch
+../_patches/patch157-kerbside-tempest-spice-direct.patch

--- a/kolla-ansible/ORDER
+++ b/kolla-ansible/ORDER
@@ -3,3 +3,4 @@
 ../_patches/patch134-kolla-ansible-master-allow-concurrent-spice-connections.patch
 ../_patches/patch147-kolla-ansible-master-kolla-ansible-kerbside-role.patch
 ../_patches/patch156-tempest-tests.patch
+../_patches/patch157-kerbside-tempest-spice-direct.patch


### PR DESCRIPTION
Stacks on patch156 (the kerbside scenario jobs) to actually run the spice-direct Tempest test the scenario was built to exercise. Adds a new kolla_ansible_tempest_discover_overrides knob to the kolla-ansible-tempest role so the kerbside job can set compute-feature-enabled.spice_console=True, and extends kolla_ansible_tempest_regex so the test is selected alongside the existing smoke run. Patch is registered in both kolla-ansible/ORDER and kolla-ansible-wave-1/ORDER, and applies cleanly against both trees via test-apply.sh.

Prompt: After investigating today's Trixie CI failures on 976889 and 988189 (Debian mirror libssl-dev / libssl3t64 version skew, not a patch problem), Michael moved on to wiring the spice-direct Tempest test he originally landed in Nova as patch033 into the kolla-ansible kerbside scenario. He asked for a separate patch stacked on patch156 rather than an amendment, and confirmed no Depends-On is needed because patch033 has long since merged upstream and Tempest is branchless.

Assisted-By: Claude Opus 4.7 (1M context, medium effort) <noreply@anthropic.com>