### PR TITLE
Restore patch008 for spice-direct routable IP.

### DIFF
--- a/_patches/patch008-use-routable-ip-for-spice-consoles.patch
+++ b/_patches/patch008-use-routable-ip-for-spice-consoles.patch
@@ -3,26 +3,29 @@ Author: Michael Still <mikal@stillhq.com>
 Date:   Tue Jan 20 15:25:44 2026 +1100
 
     Use a routable IP for qemu SPICE consoles.
-    
+
     We currently do this is the SPICE HTML5 transcoding
     proxy, but spice-direct consoles need it as well. We
     should therefore simply always configure it.
-    
+
     Partial-Bug: #2131793 (spice-direct consoles)
     Change-Id: Ic88a58d974b71e38bc91fd7dee9eef38a0bacb87
     Signed-off-by: Michael Still <mikal@stillhq.com>
 
 diff --git a/ansible/roles/nova-cell/templates/nova.conf.j2 b/ansible/roles/nova-cell/templates/nova.conf.j2
-index 1f1d7aacc..991f9ed1f 100644
+index 50a359cad..988322b34 100644
 --- a/ansible/roles/nova-cell/templates/nova.conf.j2
 +++ b/ansible/roles/nova-cell/templates/nova.conf.j2
-@@ -67,8 +67,8 @@ jpeg_compression = {{ nova_spice_jpeg_compression }}
+@@ -87,11 +87,11 @@ jpeg_compression = {{ nova_spice_jpeg_compression }}
  zlib_compression = {{ nova_spice_zlib_compression }}
  playback_compression = {{ nova_spice_playback_compression }}
  streaming_mode = {{ nova_spice_streaming_mode }}
-+server_proxyclient_address = "{{ 'api' | kolla_address }}"
- {% if nova_spice_html5 == 'yes' %}
++server_proxyclient_address = {{ api_interface_address }}
+ {%     if enable_kerbside | bool %}
+ spice_direct_proxy_base_url = "https://{{ kolla_external_fqdn }}:13002/nova-console.vv"
+ {%     endif %}
+ {%     if nova_spice_html5 | bool %}
 -server_proxyclient_address = {{ api_interface_address }}
- {% if inventory_hostname in groups[nova_cell_compute_group] %}
+ {%         if inventory_hostname in groups[nova_cell_compute_group] %}
  html5proxy_base_url = {{ nova_spicehtml5proxy_fqdn | kolla_url(public_protocol, nova_spicehtml5proxy_public_port, '/spice_auto.html') }}
- {% endif %}
+ {%         endif %}

--- a/kolla-ansible-wave-1/ORDER
+++ b/kolla-ansible-wave-1/ORDER
@@ -1,4 +1,5 @@
 ../_patches/patch121-kolla-ansible-master-support-secure-spice.patch
 ../_patches/patch147-kolla-ansible-master-kolla-ansible-kerbside-role.patch
+../_patches/patch008-use-routable-ip-for-spice-consoles.patch
 ../_patches/patch156-tempest-tests.patch
 ../_patches/patch157-kerbside-tempest-spice-direct.patch

--- a/kolla-ansible/ORDER
+++ b/kolla-ansible/ORDER
@@ -2,5 +2,6 @@
 ../_patches/patch064-allow-rocky-10-builds.patch
 ../_patches/patch134-kolla-ansible-master-allow-concurrent-spice-connections.patch
 ../_patches/patch147-kolla-ansible-master-kolla-ansible-kerbside-role.patch
+../_patches/patch008-use-routable-ip-for-spice-consoles.patch
 ../_patches/patch156-tempest-tests.patch
 ../_patches/patch157-kerbside-tempest-spice-direct.patch


### PR DESCRIPTION
The tempest spice-direct test connects to the host:port that Nova records in os-console-auth-tokens, which is whatever the compute is told via spice.server_proxyclient_address. Without this patch the field defaults to 127.0.0.1, so the test (and any cross-host Kerbside proxy lookup) can never reach qemu.

The patch was previously dropped because the GitHub multinode CI happens to colocate kerbside-proxy with nova-compute, hiding the bug. The upstream tempest job exercises the direct-to-hypervisor path and is an honest reproducer.

Regenerated against current kolla-ansible master (which now uses `nova_spice_html5 | bool` and reindented Jinja) and reordered after patch147 since the kerbside-role patch inserts a new block between streaming_mode and the html5 conditional.

Prompt: Investigate why the kerbside spice-direct tempest scenario fails in upstream Zuul while the GitHub multinode CI passes. After diagnosing that Nova returns 127.0.0.1 to the test because spice.server_proxyclient_address is unset, restore the previously dropped patch008 (Ic88a58d9), regenerate it against current upstream, and add it to the kolla-ansible and kolla-ansible-wave-1 ORDER files.