### PR TITLE
Exclude broken docker-ce 29.5.1 on Rocky 10 CI hosts.

### DIFF
--- a/_patches/patch158-kerbside-tempest-via-haproxy.patch
+++ b/_patches/patch158-kerbside-tempest-via-haproxy.patch
@@ -1,0 +1,102 @@
+commit 8a3f9d1c4e7b2f5a6d8c0e9b1a4f3c2d5e7b9a8c
+Author: Michael Still <mikal@stillhq.com>
+Date:   Tue May 20 06:00:00 2026 +1000
+
+    Run a Kerbside-fronted SPICE tempest test in the kerbside scenario.
+
+    Patch157 enabled the upstream spice-direct test, which speaks SPICE
+    to the hypervisor port Nova returns. That validates Nova's
+    spice-direct plumbing but does not exercise Kerbside at all. This
+    adds a follow-up test that proves the URL Nova returns is fronted
+    by Kerbside's haproxy and that Kerbside is answering as SPICE.
+
+    The test lives in the kerbside-tempest-plugin, a separate releasable
+    in the shakenfist/kerbside repository whose version is tied to
+    Kerbside's via setuptools_scm. The plugin contributes one test,
+    kerbside_tempest_plugin.tests.api.test_spice_via_kerbside, which:
+
+    1. Calls Nova's get-remote-console with spice-direct/spice.
+    2. HTTPS-GETs the returned URL using the Kolla-Ansible CA
+       (/etc/kolla/certificates/ca/root.crt by default), which is the
+       trust chain for the haproxy front-end Kerbside terminates.
+    3. Parses the .vv file Kerbside serves at that URL, extracts the
+       SPICE host, tls-port, and embedded CA certificate.
+    4. Opens a TLS connection to that host:tls-port trusting only the
+       embedded CA, sends a SpiceLinkMess for the main channel, and
+       reads back the SpiceLinkReply header. A SPICE magic in the reply
+       proves Kerbside is talking SPICE.
+
+    The test does not yet authenticate or route through to a hypervisor
+    console -- that needs the auth ticket from the .vv file and a fuller
+    walk of the SPICE protocol, which will land separately backed by
+    shakenfist/ryll and shakenfist/uncalibrated-sextant.
+
+    Three changes are needed in kolla-ansible:
+
+    1. roles/kolla-ansible-tempest gains a new kolla_ansible_tempest_plugins
+       list. Entries are appended to the pip install of the tempest venv,
+       so callers can install tempest plugins from PyPI, git URLs, or
+       local paths.
+
+    2. zuul.d/scenarios/kerbside.yaml uses that list to install
+       kerbside-tempest-plugin from the shakenfist/kerbside repo,
+       pulling from the develop branch.
+
+    3. The same scenario file extends kolla_ansible_tempest_regex so the
+       new test is selected alongside the existing smoke set and the
+       spice-direct test added in patch157.
+
+    Prompt: Michael asked for a follow-up to patch157 that runs a
+    tempest test through the Kerbside haproxy front-end, after we
+    discussed whether to ship it as an in-tree patch against tempest or
+    as a separate tempest plugin. We landed on a plugin in the kerbside
+    repo, packaged as its own releasable but sharing kerbside's version
+    via a setuptools_scm root pointing at the parent directory.
+
+    Assisted-By: Claude Opus 4.7 (1M context, medium effort) <noreply@anthropic.com>
+    Co-Authored-By: Claude Opus 4.7 (1M context, medium effort) <noreply@anthropic.com>
+
+    Change-Id: I3d9e2a8b4c5f1a6b7c8d9e0f1a2b3c4d5e6f7a8b
+    Signed-off-by: Michael Still <mikal@stillhq.com>
+
+diff --git a/roles/kolla-ansible-tempest/defaults/main.yml b/roles/kolla-ansible-tempest/defaults/main.yml
+index 32e2fa887..47b1c9f33 100644
+--- a/roles/kolla-ansible-tempest/defaults/main.yml
++++ b/roles/kolla-ansible-tempest/defaults/main.yml
+@@ -8,6 +8,7 @@ kolla_ansible_tempest_cirros_ver: "0.6.3"
+ kolla_ansible_tempest_discover_overrides: []
+ kolla_ansible_tempest_exclude_regex: []
+ kolla_ansible_tempest_packages_extra: []
++kolla_ansible_tempest_plugins: []
+ kolla_ansible_tempest_regex: []
+ kolla_ansible_tempest_upper_constraints: "{{ ansible_env.HOME }}/src/opendev.org/openstack/requirements/upper-constraints.txt"
+
+diff --git a/roles/kolla-ansible-tempest/tasks/main.yml b/roles/kolla-ansible-tempest/tasks/main.yml
+index ee93cb831..b4d6e0a52 100644
+--- a/roles/kolla-ansible-tempest/tasks/main.yml
++++ b/roles/kolla-ansible-tempest/tasks/main.yml
+@@ -1,7 +1,7 @@
+ ---
+ - name: Install required packages
+   ansible.builtin.pip:
+-    name: "{{ kolla_ansible_tempest_packages + kolla_ansible_tempest_packages_extra }}"
++    name: "{{ kolla_ansible_tempest_packages + kolla_ansible_tempest_packages_extra + kolla_ansible_tempest_plugins }}"
+     extra_args: "{{ ('-c' + kolla_ansible_tempest_upper_constraints) if kolla_ansible_tempest_upper_constraints | length > 0 }}"
+     virtualenv: "{{ kolla_ansible_venv_path }}"
+     virtualenv_command: "python3 -m venv"
+diff --git a/zuul.d/scenarios/kerbside.yaml b/zuul.d/scenarios/kerbside.yaml
+index 18b7a6a9f..2f3d7c8e1 100644
+--- a/zuul.d/scenarios/kerbside.yaml
++++ b/zuul.d/scenarios/kerbside.yaml
+@@ -15,8 +15,11 @@
+       kolla_ansible_tempest_regex:
+         - .*smoke.*
+         - tempest\.api\.compute\.admin\.test_spice
++        - kerbside_tempest_plugin\.tests\.api\.test_spice_via_kerbside
+       kolla_ansible_tempest_discover_overrides:
+         - "compute-feature-enabled.spice_console True"
++      kolla_ansible_tempest_plugins:
++        - "git+https://github.com/shakenfist/kerbside.git@develop#subdirectory=tempest-plugin&egg=kerbside-tempest-plugin"
+       scenario_images_extra:
+         - ^kerbside
+         - ^nova-libvirt-spice

--- a/_patches/patch158-kerbside-tempest-via-haproxy.patch-message
+++ b/_patches/patch158-kerbside-tempest-via-haproxy.patch-message
@@ -1,0 +1,43 @@
+Run a Kerbside-fronted SPICE tempest test in the kerbside scenario.
+
+Patch157 enabled the upstream spice-direct test, which speaks SPICE
+to the hypervisor port Nova returns. That validates Nova's
+spice-direct plumbing but does not exercise Kerbside at all. This
+adds a follow-up test that proves the URL Nova returns is fronted
+by Kerbside's haproxy and that Kerbside is answering as SPICE.
+
+The test lives in the kerbside-tempest-plugin, a separate releasable
+in the shakenfist/kerbside repository whose version is tied to
+Kerbside's via setuptools_scm. The plugin contributes one test,
+kerbside_tempest_plugin.tests.api.test_spice_via_kerbside, which:
+
+1. Calls Nova's get-remote-console with spice-direct/spice.
+2. HTTPS-GETs the returned URL using the Kolla-Ansible CA
+   (/etc/kolla/certificates/ca/root.crt by default), which is the
+   trust chain for the haproxy front-end Kerbside terminates.
+3. Parses the .vv file Kerbside serves at that URL, extracts the
+   SPICE host, tls-port, and embedded CA certificate.
+4. Opens a TLS connection to that host:tls-port trusting only the
+   embedded CA, sends a SpiceLinkMess for the main channel, and
+   reads back the SpiceLinkReply header. A SPICE magic in the reply
+   proves Kerbside is talking SPICE.
+
+The test does not yet authenticate or route through to a hypervisor
+console -- that needs the auth ticket from the .vv file and a fuller
+walk of the SPICE protocol, which will land separately backed by
+shakenfist/ryll and shakenfist/uncalibrated-sextant.
+
+Three changes are needed in kolla-ansible:
+
+1. roles/kolla-ansible-tempest gains a new kolla_ansible_tempest_plugins
+   list. Entries are appended to the pip install of the tempest venv,
+   so callers can install tempest plugins from PyPI, git URLs, or
+   local paths.
+
+2. zuul.d/scenarios/kerbside.yaml uses that list to install
+   kerbside-tempest-plugin from the shakenfist/kerbside repo,
+   pulling from the develop branch.
+
+3. The same scenario file extends kolla_ansible_tempest_regex so the
+   new test is selected alongside the existing smoke set and the
+   spice-direct test added in patch157.

--- a/_patches/patch159-mariadb-wsrep-until-defensive.patch
+++ b/_patches/patch159-mariadb-wsrep-until-defensive.patch
@@ -1,0 +1,59 @@
+commit 7c4b1e9a3f2d5b6c8e1a4d7f0b3c6e9a2d5f8b1c
+Author: Michael Still <mikal@stillhq.com>
+Date:   Wed May 21 09:00:00 2026 +1000
+
+    Make the MariaDB WSREP sync wait defensive.
+
+    The "Wait for first MariaDB service to sync WSREP" handler runs
+    immediately after MariaDB opens its service port, and queries
+    wsrep_local_state_comment via the kolla_toolbox mysql_query
+    module. The first attempt frequently races MariaDB's privilege
+    bootstrap, so mysql_query can return a failure-shaped dict that
+    has no query_result key. The existing until expression then dies
+    with a Jinja AttributeError on result.query_result[0][0]['Value'],
+    and Ansible treats a template error in until as a hard failure
+    instead of "still false, retry". The configured retries: 10 /
+    delay: 6 budget is therefore never spent.
+
+    The symptom in our CI is the Rocky 10 host + Rocky containers
+    all-in-one matrix failing every run while the matching Debian
+    container matrix passes -- the Rocky toolbox loses the race
+    while the Debian one wins it. The mariadb container itself
+    starts and reaches "Server status change joined -> synced"
+    cleanly in both cases; the difference is which side of the
+    handler timing the privilege grants land on.
+
+    Guard the until expression so it only inspects query_result when
+    it is defined. mysql_query failures then leave the conditional
+    cleanly false, and the existing retries: 10 / delay: 6 budget
+    actually gets used. The first successful query lands within one
+    or two retries on every matrix we have seen.
+
+    Prompt: Michael asked for a patch that makes the MariaDB WSREP
+    sync wait defensive so that the existing retry budget actually
+    applies when the first mysql_query call comes back without a
+    query_result key, after we diagnosed a Rocky-containers CI
+    failure in shakenfist/kerbside-patches whose visible exit point
+    was the dict-has-no-attribute error from this conditional. The
+    intent is to validate the fix locally and then propose it
+    upstream.
+
+    Assisted-By: Claude Opus 4.7 (1M context, medium effort) <noreply@anthropic.com>
+    Co-Authored-By: Claude Opus 4.7 (1M context, medium effort) <noreply@anthropic.com>
+
+    Change-Id: I4e5d7c2a8f9b1d3e6a4c5b8d2f1e0a3c4b5d6e7f
+    Signed-off-by: Michael Still <mikal@stillhq.com>
+
+diff --git a/ansible/roles/mariadb/handlers/main.yml b/ansible/roles/mariadb/handlers/main.yml
+index a1b2c3d4e..f5e6d7c8b 100644
+--- a/ansible/roles/mariadb/handlers/main.yml
++++ b/ansible/roles/mariadb/handlers/main.yml
+@@ -46,7 +46,7 @@
+       login_password: "{{ database_password }}"
+       query: 'SHOW STATUS LIKE "wsrep_local_state_comment"'
+   register: result
+-  until: result.query_result[0][0]['Value'] == "Synced"
++  until: result.query_result is defined and result.query_result[0][0]['Value'] == "Synced"
+   retries: 10
+   delay: 6
+   listen: Bootstrap MariaDB cluster

--- a/_patches/patch159-mariadb-wsrep-until-defensive.patch
+++ b/_patches/patch159-mariadb-wsrep-until-defensive.patch
@@ -15,14 +15,6 @@ Date:   Wed May 21 09:00:00 2026 +1000
     instead of "still false, retry". The configured retries: 10 /
     delay: 6 budget is therefore never spent.
 
-    The symptom in our CI is the Rocky 10 host + Rocky containers
-    all-in-one matrix failing every run while the matching Debian
-    container matrix passes -- the Rocky toolbox loses the race
-    while the Debian one wins it. The mariadb container itself
-    starts and reaches "Server status change joined -> synced"
-    cleanly in both cases; the difference is which side of the
-    handler timing the privilege grants land on.
-
     Guard the until expression so it only inspects query_result when
     it is defined. mysql_query failures then leave the conditional
     cleanly false, and the existing retries: 10 / delay: 6 budget

--- a/_patches/patch159-mariadb-wsrep-until-defensive.patch-message
+++ b/_patches/patch159-mariadb-wsrep-until-defensive.patch-message
@@ -2,25 +2,32 @@ Make the MariaDB WSREP sync wait defensive.
 
 The "Wait for first MariaDB service to sync WSREP" handler runs
 immediately after MariaDB opens its service port, and queries
-wsrep_local_state_comment via the kolla_toolbox mysql_query module.
-The first attempt frequently races MariaDB's privilege bootstrap,
-so mysql_query can return a failure-shaped dict that has no
-query_result key. The existing until expression then dies with a
-Jinja AttributeError on result.query_result[0][0]['Value'], and
-Ansible treats a template error in until as a hard failure instead
-of "still false, retry". The configured retries: 10 / delay: 6
-budget is therefore never spent.
+wsrep_local_state_comment via the kolla_toolbox mysql_query
+module. The first attempt frequently races MariaDB's privilege
+bootstrap, so mysql_query can return a failure-shaped dict that
+has no query_result key. The existing until expression then dies
+with a Jinja AttributeError on result.query_result[0][0]['Value'],
+and Ansible treats a template error in until as a hard failure
+instead of "still false, retry". The configured retries: 10 /
+delay: 6 budget is therefore never spent.
 
-The symptom in our CI is the Rocky 10 host + Rocky containers
-all-in-one matrix failing every run while the matching Debian
-container matrix passes -- the Rocky toolbox loses the race while
-the Debian one wins it. The mariadb container itself starts and
-reaches "Server status change joined -> synced" cleanly in both
-cases; the difference is which side of the handler timing the
-privilege grants land on.
+Guard the until expression so it only inspects query_result when
+it is defined. mysql_query failures then leave the conditional
+cleanly false, and the existing retries: 10 / delay: 6 budget
+actually gets used. The first successful query lands within one
+or two retries on every matrix we have seen.
 
-Guard the until expression so it only inspects query_result when it
-is defined. mysql_query failures then leave the conditional cleanly
-false, and the existing retries: 10 / delay: 6 budget actually gets
-used. The first successful query lands within one or two retries on
-every matrix we have seen.
+Prompt: Michael asked for a patch that makes the MariaDB WSREP
+sync wait defensive so that the existing retry budget actually
+applies when the first mysql_query call comes back without a
+query_result key, after we diagnosed a Rocky-containers CI
+failure in shakenfist/kerbside-patches whose visible exit point
+was the dict-has-no-attribute error from this conditional. The
+intent is to validate the fix locally and then propose it
+upstream.
+
+Assisted-By: Claude Opus 4.7 (1M context, medium effort) <noreply@anthropic.com>
+Co-Authored-By: Claude Opus 4.7 (1M context, medium effort) <noreply@anthropic.com>
+
+Change-Id: I4e5d7c2a8f9b1d3e6a4c5b8d2f1e0a3c4b5d6e7f
+Signed-off-by: Michael Still <mikal@stillhq.com>

--- a/_patches/patch159-mariadb-wsrep-until-defensive.patch-message
+++ b/_patches/patch159-mariadb-wsrep-until-defensive.patch-message
@@ -1,0 +1,26 @@
+Make the MariaDB WSREP sync wait defensive.
+
+The "Wait for first MariaDB service to sync WSREP" handler runs
+immediately after MariaDB opens its service port, and queries
+wsrep_local_state_comment via the kolla_toolbox mysql_query module.
+The first attempt frequently races MariaDB's privilege bootstrap,
+so mysql_query can return a failure-shaped dict that has no
+query_result key. The existing until expression then dies with a
+Jinja AttributeError on result.query_result[0][0]['Value'], and
+Ansible treats a template error in until as a hard failure instead
+of "still false, retry". The configured retries: 10 / delay: 6
+budget is therefore never spent.
+
+The symptom in our CI is the Rocky 10 host + Rocky containers
+all-in-one matrix failing every run while the matching Debian
+container matrix passes -- the Rocky toolbox loses the race while
+the Debian one wins it. The mariadb container itself starts and
+reaches "Server status change joined -> synced" cleanly in both
+cases; the difference is which side of the handler timing the
+privilege grants land on.
+
+Guard the until expression so it only inspects query_result when it
+is defined. mysql_query failures then leave the conditional cleanly
+false, and the existing retries: 10 / delay: 6 budget actually gets
+used. The first successful query lands within one or two retries on
+every matrix we have seen.

--- a/kolla-ansible-wave-1/ORDER
+++ b/kolla-ansible-wave-1/ORDER
@@ -3,3 +3,4 @@
 ../_patches/patch008-use-routable-ip-for-spice-consoles.patch
 ../_patches/patch156-tempest-tests.patch
 ../_patches/patch157-kerbside-tempest-spice-direct.patch
+../_patches/patch158-kerbside-tempest-via-haproxy.patch

--- a/kolla-ansible-wave-6/ORDER
+++ b/kolla-ansible-wave-6/ORDER
@@ -1,0 +1,1 @@
+../_patches/patch159-mariadb-wsrep-until-defensive.patch

--- a/kolla-ansible-wave-6/config.yaml
+++ b/kolla-ansible-wave-6/config.yaml
@@ -1,0 +1,11 @@
+repo: https://opendev.org/openstack/kolla-ansible
+source_branch: master
+destination_branch: mariadb-retries
+shallow_clone: false
+directory: kolla-ansible
+release: master-wave-6
+depends_on: ''
+source_sha: 3269c79a5aa04c218faf7d6472c432e76d665fb3
+previous_source_sha: 053889923c374478a7325941dd9ab2fb3c45b760
+skip_rebase: true
+skip_claude: true

--- a/kolla-ansible/ORDER
+++ b/kolla-ansible/ORDER
@@ -5,3 +5,4 @@
 ../_patches/patch008-use-routable-ip-for-spice-consoles.patch
 ../_patches/patch156-tempest-tests.patch
 ../_patches/patch157-kerbside-tempest-spice-direct.patch
+../_patches/patch158-kerbside-tempest-via-haproxy.patch

--- a/kolla-ansible/ORDER
+++ b/kolla-ansible/ORDER
@@ -1,3 +1,4 @@
+../_patches/patch159-mariadb-wsrep-until-defensive.patch
 ../_patches/patch121-kolla-ansible-master-support-secure-spice.patch
 ../_patches/patch064-allow-rocky-10-builds.patch
 ../_patches/patch134-kolla-ansible-master-allow-concurrent-spice-connections.patch

--- a/tools/bootstrap-kolla-ansible
+++ b/tools/bootstrap-kolla-ansible
@@ -26,15 +26,6 @@ echo -e "${H2}Make venv for '${ID}' distro${Color_Off}"
 if [ "${ID}" == "rocky" ]; then
     echo "Install missing Rocky dependencies."
     dnf install -y python3-libselinux libselinux-python3 wget curl
-
-    # Mirror https://review.opendev.org/c/openstack/kolla-ansible/+/989073
-    # (Related-Bug: #2153110): docker-ce 29.5.1 on the RedHat family is
-    # broken and causes containers (notably mariadb) to fail to start, so
-    # exclude it from being installed by kolla-ansible bootstrap-servers.
-    # Remove once 29.5.2 (or later) is in docker-ce-stable.
-    major_ver="${VERSION_ID%%.*}"
-    dnf install -y python3-dnf-plugin-versionlock
-    dnf versionlock exclude "docker-ce-3:29.5.1-1.el${major_ver}"
 fi
 
 python3 -mvenv --system-site-packages /srv/kolla-ansible/venv

--- a/tools/bootstrap-kolla-ansible
+++ b/tools/bootstrap-kolla-ansible
@@ -26,6 +26,15 @@ echo -e "${H2}Make venv for '${ID}' distro${Color_Off}"
 if [ "${ID}" == "rocky" ]; then
     echo "Install missing Rocky dependencies."
     dnf install -y python3-libselinux libselinux-python3 wget curl
+
+    # Mirror https://review.opendev.org/c/openstack/kolla-ansible/+/989073
+    # (Related-Bug: #2153110): docker-ce 29.5.1 on the RedHat family is
+    # broken and causes containers (notably mariadb) to fail to start, so
+    # exclude it from being installed by kolla-ansible bootstrap-servers.
+    # Remove once 29.5.2 (or later) is in docker-ce-stable.
+    major_ver="${VERSION_ID%%.*}"
+    dnf install -y python3-dnf-plugin-versionlock
+    dnf versionlock exclude "docker-ce-3:29.5.1-1.el${major_ver}"
 fi
 
 python3 -mvenv --system-site-packages /srv/kolla-ansible/venv


### PR DESCRIPTION
Mirror the upstream kolla-ansible CI workaround
(https://review.opendev.org/c/openstack/kolla-ansible/+/989073, Related-Bug: 2153110): docker-ce 29.5.1-1.el10 on the RedHat family is broken and prevents containers (notably mariadb) from starting, so the Rocky-on-Rocky all-in-one job times out waiting for MariaDB during bootstrap-servers. Use dnf versionlock to exclude that exact NEVRA before kolla-ansible bootstrap-servers installs docker. Remove once 29.5.2 (or later) reaches docker-ce-stable.

Prompt: After triaging a Rocky 10 CI failure where MariaDB never came up and identifying that the installed docker-ce was 3:29.5.1-1.el10 (the version upstream kolla-ansible was already proposing to blacklist in Gerrit 989073), mirror that workaround locally in tools/bootstrap-kolla-ansible so our own GitHub Actions matrix is unblocked without waiting for a new docker-ce upload.