### PR TITLE
Respect the caller's ref for kerbside and nova-specs in imagebuild.

### DIFF
--- a/_build/imagebuild.sh
+++ b/_build/imagebuild.sh
@@ -51,16 +51,21 @@ for target in ${build_targets}; do
     fi
     echo -e "${H2}Target branch is ${target_branch}${Color_Off}"
 
-    # Checkout the target branch in all our directories. Kerbside is a special
-    # case as it doesn't obey the OpenStack branch naming conventions.
+    # Checkout the target branch in our patched directories. Projects
+    # with patches in this tree have a per-release branch created by
+    # apply-patches-and-test.sh, and we need to land on that branch
+    # before kolla-build reads the source. Kerbside and nova-specs do
+    # not get patches applied here, so we leave them on whatever ref the
+    # caller supplied: assemble-source.sh's clone defaults to develop /
+    # master respectively, and CI that wants to test a specific ref
+    # (e.g. a kerbside PR scp'd over the clone) can do so without
+    # being silently reverted by this script.
     for directory in "${directories[@]}"; do
-        if [ ${directory} == "kerbside" ]; then
-            tb="develop"
-        elif [ ${directory} == "nova-specs" ]; then
-            tb="master"
-        else
-            tb="${target_branch}"
+        if [ ${directory} == "kerbside" ] || [ ${directory} == "nova-specs" ]; then
+            echo -e "${H2}${Arrow}Leaving ${directory} on its current ref${Color_Off}"
+            continue
         fi
+        tb="${target_branch}"
 
         echo -e "${H2}${Arrow}Checkout ${tb} in ${directory}${Color_Off}"
         pushd ${topsrcdir}/${directory}


### PR DESCRIPTION
imagebuild.sh hard-coded `git checkout develop` for kerbside and `git checkout master` for nova-specs before invoking kolla-build. Neither project has patches applied in this tree, so the checkout was vestigial -- assemble-source.sh's clone already lands on those branches by default. The hard-coded checkout did silently revert the source dir when something *else* had set up a different ref: in particular, kerbside's GitHub Actions CI scp's the PR checkout over src/kerbside so the deployed container reflects the PR, but this checkout reverted it back to develop before the image build. The same shape of problem would block a Depends-On against a kerbside change in kerbside-patches' own CI.

For projects that *do* have patches in this tree, apply-patches- and-test.sh creates a per-release `*-patches` branch, and we still need to land on it for kolla-build to see the patched source -- that path is unchanged.

Prompt: Michael asked me to fix this in kerbside-patches rather than keep the workaround in kerbside's workflow, after we traced a Tempest CI failure on shakenfist/kerbside PR #72 to imagebuild.sh overwriting the scp'd PR source.

Assisted-By: Claude Opus 4.7 (1M context, low effort) <noreply@anthropic.com>