### PR TITLE
Use the local kerbside and nova checkouts for master image builds.

### DIFF
--- a/etc/kolla-build-master.conf.in
+++ b/etc/kolla-build-master.conf.in
@@ -5,3 +5,11 @@ base_image = BASE_IMAGE
 debug = true
 push = false
 use_ligenix_qemu = true
+
+[kerbside-base]
+type = local
+location = TOPSRCDIR/kerbside
+
+[nova-base]
+type = local
+location = TOPSRCDIR/nova


### PR DESCRIPTION
etc/kolla-build-2025.1.conf.in and etc/kolla-build-2025.2.conf.in both override the kolla source map so that the kerbside-base and nova-base images build from TOPSRCDIR/kerbside and TOPSRCDIR/nova on disk. etc/kolla-build-master.conf.in was missing those sections, so master builds silently fell back to kolla's default sources.py entry for kerbside and pulled the released
https://shakenfist.com/kerbside/releases/kerbside-master.tar.gz instead. Any local edits to src/kerbside -- including kerbside- patches' own assemble-source.sh clone and CI workflows that scp a PR checkout over the top of it -- never reached the image build.

This surfaced in shakenfist/kerbside PR #72: the kerbside_proxy container kept hitting a parse_capabilities crash even though the fix was on the PR's tempest branch, because the deployed container was built from the release tarball.

Mirror the 2025.x configs by adding [kerbside-base] and [nova-base] sections pointing at TOPSRCDIR. No effect on releases that already had these overrides.

Prompt: Michael flagged the kerbside PR's Tempest job still failing after PR #1262 landed. Pulled the proxy container logs from the bundle, confirmed they still showed the pre-fix kerbside source, then traced through kolla-build sources.py and found the master conf was missing the local-source overrides.

Assisted-By: Claude Opus 4.7 (1M context, low effort) <noreply@anthropic.com>